### PR TITLE
Adding permission for delete review workflow

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      pull-requests: write
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Context
This new service Register of training providers to be onboarded with teacher service

## Changes proposed in this pull request
Adding permission for delete review workflow

## Guidance to review
Check workflow to see if the run is successful
https://github.com/DFE-Digital/register-training-providers/actions/runs/14998100664

## Link to Trello card
https://trello.com/c/Qs3GoLjP/2330-new-service-register-of-training-providers

## Checklist

- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Tested by running locally