### PR TITLE
[0099] Fixed sass issues

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -2,7 +2,7 @@ $govuk-global-styles: true;
 $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
-@import "govuk-frontend/dist/govuk/all";
+@import "govuk-frontend/dist/govuk";
 
 .no-border.govuk-phase-banner {
   border-bottom: none;

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -3,7 +3,3 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
 @use "govuk-frontend/dist/govuk";
-
-.no-border.govuk-phase-banner {
-  border-bottom: none;
-}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -2,7 +2,7 @@ $govuk-global-styles: true;
 $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
-@import "govuk-frontend/dist/govuk";
+@use "govuk-frontend/dist/govuk";
 
 .no-border.govuk-phase-banner {
   border-bottom: none;


### PR DESCRIPTION
When running

```bash
bundle exec rails assets:precompile
```

```txt
Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
More info and automated migrator: https://sass-lang.com/d/import
...

Warning: Importing using 'govuk/all' is deprecated. Update your import statement to import 'govuk/index'. To silence this warning, update $govuk-suppressed-warnings with key: "import-using-all"
...
```

