### PR TITLE
[0077] Implement personas

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,14 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   private
+  # dfe and otp objects can both be instantiated as `.begin_session!` will always create
+  # a session with a dfe/otp_sign_in_user hash regardless of there being a user/email.
+  # We only want to memoize the instance that responds to #user hence the `.select`
+  def sign_in_user
+    @sign_in_user ||= [
+      DfESignInUser.load_from_session(session),
+    ].select { |x| x.try(:user) }.first
+  end
 
   def current_user
     @current_user ||= sign_in_user&.user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,32 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate
+
+  helper_method :current_user, :authenticated?
+
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  private
+
+  def current_user
+    @current_user ||= sign_in_user&.user
+  end
+
+  def authenticated?
+    current_user.present?
+  end
+
+  def save_requested_path
+    session[:requested_path] = request.fullpath
+  end
+
+  def save_requested_path_and_redirect
+    save_requested_path
+    redirect_to(sign_in_path)
+  end
+
+  def authenticate
+    save_requested_path_and_redirect unless authenticated?
+  end
 end

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -1,4 +1,6 @@
 class LandingPageController < ApplicationController
+  skip_before_action :authenticate
+
   def start
   end
 end

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,0 +1,7 @@
+class PersonasController < ApplicationController
+  # skip_before_action :authenticate
+
+  def index
+    @personas = Persona.order(:email) + [Persona.non_existing_persona]
+  end
+end

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,5 +1,5 @@
 class PersonasController < ApplicationController
-  # skip_before_action :authenticate
+  skip_before_action :authenticate
 
   def index
     @personas = Persona.order(:email) + [Persona.non_existing_persona]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,27 @@
+class SessionsController < ApplicationController
+  skip_before_action :authenticate
+
+  def callback
+    DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
+
+    if current_user
+      DfESignInUsers::Update.call(user: current_user, sign_in_user: sign_in_user)
+
+      redirect_to(login_redirect_path)
+    else
+      session.delete(:requested_path)
+      DfESignInUser.end_session!(session)
+      redirect_to(sign_in_user_not_found_path)
+    end
+  end
+
+  def signout
+    redirect_to(root_path)
+  end
+
+private
+
+  def login_redirect_path
+    session.delete(:requested_path) || providers_path
+  end
+end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,5 +1,5 @@
 class SignInController < ApplicationController
-  # skip_before_action :authenticate
+  skip_before_action :authenticate
 
   def index
     sign_in_method

--- a/app/lib/service_pattern.rb
+++ b/app/lib/service_pattern.rb
@@ -1,0 +1,20 @@
+module ServicePattern
+  def self.included(base)
+    base.extend(ClassMethods)
+    base.class_eval do
+      private_class_method(:new)
+    end
+  end
+
+  def call
+    raise(NotImplementedError("#call must be implemented"))
+  end
+
+  module ClassMethods
+    def call(*args, **keyword_args, &block)
+      return new.call if args.empty? && keyword_args.empty? && block.nil?
+
+      new(*args, **keyword_args, &block).call
+    end
+  end
+end

--- a/app/services/dfe_sign_in_users/update.rb
+++ b/app/services/dfe_sign_in_users/update.rb
@@ -1,0 +1,30 @@
+module DfESignInUsers
+  class Update
+    include ServicePattern
+
+    attr_reader :user, :successful
+
+    alias_method :successful?, :successful
+
+    def initialize(user:, sign_in_user:)
+      @user = user
+
+      attributes = {
+        last_signed_in_at: Time.zone.now,
+        email: sign_in_user.email,
+        dfe_sign_in_uid: sign_in_user.dfe_sign_in_uid,
+      }
+
+      attributes[:first_name] = sign_in_user.first_name if sign_in_user.first_name.present?
+      attributes[:last_name] = sign_in_user.last_name if sign_in_user.last_name.present?
+
+      @user.assign_attributes(attributes)
+    end
+
+    def call
+      @successful = user.valid? && user.save!
+
+      self
+    end
+  end
+end

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,0 +1,3 @@
+<% page_data(title: "Test users") %>
+
+<%= render Personas::View.with_collection(@personas) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,12 @@ Rails.application.routes.draw do
   get "/sign-out" => "sign_out#index"
   get "/sign-in/user-not-found", to: "sign_in#new"
 
+  case Env.sign_in_method("dfe-sign-in")
+  when "persona"
+    get("/personas", to: "personas#index")
+    get("/auth/developer/sign-out", to: "sessions#signout")
+    post("/auth/developer/callback", to: "sessions#callback")
+  end
+
   resources :providers, only: %i[index]
 end


### PR DESCRIPTION
### Context
Sign in as a persona/test user

### Changes proposed in this pull request
Added the sign in flow for persona



### Guidance to review
Viewable here
https://register-training-providers-pr-49.test.teacherservices.cloud/

Use the browser back button as the sign out is not in place yet.

The full signin flow in with 
- a valid user
- a soft deleted user
- a non existence user

![image](https://github.com/user-attachments/assets/8b7dd9bf-165f-4042-a6b6-b953525c6f41)


All of which is to mimic what shape a user can attempt to long in.

For the valid user there is not much to see other then empty `Providers`

![image](https://github.com/user-attachments/assets/75c72714-23b6-4409-83f3-66327c7682e6)


For the other 2 users they will land on the `Ask for an account to access the Register of training providers`

![image](https://github.com/user-attachments/assets/5b8cd2ef-bf14-4f10-9706-a37b0b341034)
