### PR TITLE
[0077] Added user not found page

### DIFF
--- a/app/helpers/support_email_helper.rb
+++ b/app/helpers/support_email_helper.rb
@@ -1,0 +1,7 @@
+module SupportEmailHelper
+  def support_email(name: nil, subject: nil, classes: nil)
+    default_classes = "app-!-overflow-break-word"
+
+    govuk_mail_to(I18n.t("service.email"), name, subject: subject, class: "#{default_classes} #{classes}")
+  end
+end

--- a/app/views/sign_in/new.html.erb
+++ b/app/views/sign_in/new.html.erb
@@ -1,0 +1,9 @@
+<%= render PageTitle::View.new(text: t(".heading")) %>
+
+<h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+<p class="govuk-body"><%= t(".body") %></p>
+
+<p class="govuk-body">
+  <%= t(".contact_us_html", link: support_email(subject: "Get access to Register of training providers")) %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
   sign_in:
     new:
       heading: Ask for an account to access the Register of training providers
-      body: Although you have a DfE Sign-in account, you also need an account on Register of training providers.
+      body: Although you have a DfE Sign-in account, you also need an account to access the Register of training providers.
       contact_us_html: If you think you should have an account, email us at %{link}.
     index:
       heading: Sign in to Register of training providers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,10 @@ en:
     name: Register of training providers
     email: becomingateacher@digital.education.gov.uk
   sign_in:
+    new:
+      heading: Ask for an account to Register of training providers
+      body: Although you have a DfE Sign-in account, you also need an account on Register of training providers.
+      contact_us_html: If you think you should have an account, email us at %{link}.
     index:
       heading: Sign in to Register of training providers
       dfe_sign_in:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
     email: becomingateacher@digital.education.gov.uk
   sign_in:
     new:
-      heading: Ask for an account to Register of training providers
+      heading: Ask for an account to access the Register of training providers
       body: Although you have a DfE Sign-in account, you also need an account on Register of training providers.
       contact_us_html: If you think you should have an account, email us at %{link}.
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   get "/sign-in" => "sign_in#index"
   get "/sign-out" => "sign_out#index"
+  get "/sign-in/user-not-found", to: "sign_in#new"
 
   resources :providers, only: %i[index]
 end


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bbb54c72-868a-4a97-8420-5135665b4ea7)

Viewable at
https://register-training-providers-pr-54.test.teacherservices.cloud/sign-in/user-not-found


Based on 

https://becoming-a-teacher.design-history.education.gov.uk/register-of-training-providers/service-error-pages/#account-not-recognised