### PR TITLE
Adding CICD to prod env, configuring for production readyness

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [qa, staging]
+        environment: [qa, staging, production]
 
     steps:
       - name: Deploy app to ${{ matrix.environment }}

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -30,6 +30,7 @@ module "web_application" {
   environment  = var.environment
   service_name = var.service_name
   probe_path = null
+  replicas     = var.replicas
 
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -1,8 +1,17 @@
 {
   "cluster": "production",
   "namespace": "bat-production",
+  "replicas": 2,
+  "postgres_enable_high_availability": true,
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "enable_postgres_backup_storage": true,
+  "enable_logit": true,
   "enable_monitoring": true,
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 3,
+    "start_minute": 0
+  },
   "external_url": "https://register-of-training-providers.education.gov.uk/healthcheck",
   "apex_url": "https://register-of-training-providers.education.gov.uk",
   "statuscake_contact_groups": [282453]

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -12,4 +12,7 @@ module "postgres" {
   azure_enable_monitoring     = var.enable_monitoring
   azure_enable_backup_storage = var.enable_postgres_backup_storage
   server_version              = "16"
+  azure_maintenance_window    = var.azure_maintenance_window
+  azure_enable_high_availability = var.postgres_enable_high_availability
+  azure_sku_name              = var.postgres_flexible_server_sku
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -79,3 +79,22 @@ locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 
 }
+variable "enable_logit" { default = true }
+
+variable "replicas" {
+  default = 1
+  type = number
+}
+
+variable "azure_maintenance_window" {
+  default = null
+}
+
+variable "postgres_flexible_server_sku" {
+  default = "B_Standard_B1ms"
+}
+
+variable "postgres_enable_high_availability" {
+  default = false
+}
+


### PR DESCRIPTION
## Context
This new service Register of training providers to be onboarded with teacher service

## Changes proposed in this pull request
Adding CICD for prod env, production readyness

## Guidance to review
prod app is deployed https://register-training-providers-production.teacherservices.cloud/
Validate
make production terraform-plan CONFIRM_PRODUCTION=yes

## Link to Trello card
https://trello.com/c/Qs3GoLjP/2330-new-service-register-of-training-providers

## Checklist
- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Tested by running locally