### PR TITLE
Fixing the DB backup workflow and adding storage account for db backup in staging env

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -25,6 +25,8 @@ on:
   # schedule:
   #   - cron: "0 4 * * *" # 04:00 UTC
   # change the backup time as required by the application
+permissions:
+  id-token: write
 
 env:
   SERVICE_NAME: register-training-providers
@@ -46,15 +48,16 @@ jobs:
 
       - uses: azure/login@v2
         with:
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 
       - name: Set environment variables
         run: |
           source global_config/${DEPLOY_ENV}.sh
           tf_vars_file=${TF_VARS_PATH}/${DEPLOY_ENV}.tfvars.json
           echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "NAMESPACE=$(jq -r '.namespace' ${tf_vars_file})" >> $GITHUB_ENV
           echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
           echo "STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}dbbkp${CONFIG_SHORT}sa" >> $GITHUB_ENV
           TODAY=$(date +"%F")

--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -1,4 +1,7 @@
 {
   "cluster": "test",
-  "namespace": "bat-staging"
+  "namespace": "bat-staging",
+  "environment": "staging",
+  "enable_postgres_backup_storage": true,
+  "enable_logit": true
 }


### PR DESCRIPTION
## Context
This new service Register of training providers to be onboarded with teacher service

## Changes proposed in this pull request
Fixing the DB backup workflow and adding storage account for db backup in staging env

## Guidance to review
Check the db backup taken for staging env
https://github.com/DFE-Digital/register-training-providers/actions/runs/15343051809/job/43173213782

## Link to Trello card
https://trello.com/c/Qs3GoLjP/2330-new-service-register-of-training-providers

## Checklist
- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Tested by running locally