### PR TITLE
[0079] Add support user flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :authenticated?
 
-  default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,4 +4,17 @@ class UsersController < ApplicationController
   def index
     @pagy, @records = pagy(User.kept.order_by_first_then_last_name)
   end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(params.require(:user).permit(:first_name, :last_name, :email))
+    if @user.valid?
+      # todo
+    else
+      render(:new)
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(params.require(:user).permit(:first_name, :last_name, :email))
     if @user.valid?
-      # todo
+      @user.save!
+
+      redirect_to users_path, flash: { success: "Support user added" }
     else
       render(:new)
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,15 @@
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
+            <% if flash.any? %>
+              <% flash.each do |key, message| %>
+                <% if key == "success" %>
+                  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
+                    <% nb.with_heading(text: message) %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
             <%= yield(:page_alerts) %>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,6 +50,11 @@
       <%= yield :breadcrumbs %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <%= yield(:page_alerts) %>
+          </div>
+        </div>
+        <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <%= yield(:page_header) %>
             <%= yield %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,7 @@
 <% page_data(title: "Support users (#{govuk_number(@pagy.count)})") %>
 
+<%= govuk_button_link_to("Add user", new_user_path) %>
+
 <%= govuk_table do |table|
   table.with_head do |head|
     head.with_row do |row|

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,9 @@
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+        text: "Back",
+        href: users_path,
+  ) %>
+<% end %>
 
 <%= form_for @user  do  |f| %>
   <% page_data(title: "Add support user", header: false, error: @user.errors.present? ) %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,17 @@
+
+<%= form_for @user  do  |f| %>
+  <% page_data(title: "Add support user", header: false, error: @user.errors.present? ) %>
+
+  <%= content_for(:page_alerts) { f.govuk_error_summary } %>
+
+  <%= f.govuk_fieldset legend: { text: "Personal Details" }, caption: { text: "Add support user" } do %>
+    <%= f.govuk_text_field :first_name,   width: 'two-thirds',    label: { size: 's', text: 'First name' } %>
+    <%= f.govuk_text_field :last_name,   width: 'two-thirds',    label: { size: 's', text: 'Last name' } %>
+    <%= f.govuk_text_field :email, width: 'full',    label: { size: 's', text: 'Email' }, hint: {text: "Email must be a valid Department for Education address, like name@education.gov.uk"} %>
+    <%= f.govuk_submit %>
+  <% end %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to("Cancel", users_path) %>
+</p>

--- a/config/initializers/govuk_formbuilder.rb
+++ b/config/initializers/govuk_formbuilder.rb
@@ -1,13 +1,15 @@
 GOVUKDesignSystemFormBuilder.configure do |config|
+
+
   # for more info see:
   #
   # https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder
 
   # config.brand: 'govuk'
   #
-  # config.default_legend_size: 'm'
-  # config.default_legend_tag: nil
-  # config.default_caption_size: 'm'
+  config.default_legend_size          = 'l'
+  config.default_legend_tag           = 'h1'
+  config.default_caption_size         = 'l'
   # config.default_submit_button_text: 'Continue'
   # config.default_radio_divider_text: 'or'
   # config.default_check_box_divider_text: 'or'
@@ -28,3 +30,5 @@ GOVUKDesignSystemFormBuilder.configure do |config|
   # config.enable_logger: true
   # config.trust_error_messages: false
 end
+
+ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,5 +24,5 @@ Rails.application.routes.draw do
   end
 
   resources :providers, only: %i[index]
-  resources :users, only: %i[index]
+  resources :users, only: %i[index new create]
 end

--- a/spec/support/features/matchers/back_link_matcher.rb
+++ b/spec/support/features/matchers/back_link_matcher.rb
@@ -1,0 +1,20 @@
+RSpec::Matchers.define :have_back_link do |expected_href|
+  include CapybaraNodeHelper
+  match do |content|
+    # Wrap the content string in a Capybara node for matcher support
+    node = wrap_as_capybara_node(content)
+    node.has_link?("Back", href: expected_href)
+  end
+
+  failure_message do |content|
+    "expected that content would have a 'Back' link to #{expected_href}, but it did not.\nContent was:\n#{content}"
+  end
+
+  failure_message_when_negated do |_content|
+    "expected that content would NOT have a 'Back' link to #{expected_href}, but it did."
+  end
+
+  description do
+    "have a 'Back' link to #{expected_href}"
+  end
+end

--- a/spec/support/features/matchers/back_link_matcher.rb
+++ b/spec/support/features/matchers/back_link_matcher.rb
@@ -1,7 +1,6 @@
 RSpec::Matchers.define :have_back_link do |expected_href|
   include CapybaraNodeHelper
   match do |content|
-    # Wrap the content string in a Capybara node for matcher support
     node = wrap_as_capybara_node(content)
     node.has_link?("Back", href: expected_href)
   end

--- a/spec/support/features/matchers/capybara_node_helper.rb
+++ b/spec/support/features/matchers/capybara_node_helper.rb
@@ -1,0 +1,9 @@
+module CapybaraNodeHelper
+  def wrap_as_capybara_node(input)
+    if input.respond_to?(:has_css?) && input.respond_to?(:find)
+      input
+    else
+      Capybara::Node::Simple.new(input.to_s)
+    end
+  end
+end

--- a/spec/support/features/matchers/error_summary_matcher.rb
+++ b/spec/support/features/matchers/error_summary_matcher.rb
@@ -1,0 +1,21 @@
+RSpec::Matchers.define :have_error_summary do |*expected_messages|
+  include CapybaraNodeHelper
+
+  match do |page_or_html|
+    node = wrap_as_capybara_node(page_or_html)
+    node.has_css?(".govuk-error-summary") &&
+      expected_messages.all? do |msg|
+        node.all(".govuk-error-summary__list li a").map(&:text).include?(msg)
+      end
+  end
+
+  failure_message do |page_or_html|
+    node = wrap_as_capybara_node(page_or_html)
+    actual = node.has_css?('.govuk-error-summary') ? node.all('.govuk-error-summary__list li a').map(&:text) : []
+    "expected error summary to include #{expected_messages.inspect}, but got #{actual.inspect}"
+  end
+
+  failure_message_when_negated do |_page|
+    "expected not to find error summary element with CSS selector '.govuk-error-summary', but found one"
+  end
+end

--- a/spec/support/features/matchers/pagination_matcher.rb
+++ b/spec/support/features/matchers/pagination_matcher.rb
@@ -1,0 +1,16 @@
+RSpec::Matchers.define :have_pagination do
+  include CapybaraNodeHelper
+
+  match do |page_or_html|
+    node = wrap_as_capybara_node(page_or_html)
+    node.has_css?('.govuk-pagination')
+  end
+
+  failure_message do |_page|
+    "expected to find pagination element with CSS selector '.govuk-pagination' but none found"
+  end
+
+  failure_message_when_negated do |_page|
+    "expected not to find pagination element with CSS selector '.govuk-pagination' but found one"
+  end
+end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "users/index.html.erb", type: :view do
+  let(:user_1) { build_stubbed(:user, first_name: "Alice") }
+  let(:user_2) { build_stubbed(:user, first_name: "Bob") }
+  let(:users) { [user_1, user_2] }
+  let(:count) {users.size}
+  let(:pagy) { Pagy.new(count: count, page: 1) }
+
+  let(:pagination_component) { instance_double(PaginationDisplay::View) }
+
+  before do
+    assign(:records, users)
+    assign(:pagy, pagy)
+    allow(view).to receive(:page_data)
+
+    render
+  end
+
+  it "calls page_data with govuk_number count" do
+    expect(view).to have_received(:page_data).with(title: "Support users (2)")
+  end
+
+  it "renders the add user button" do
+    expect(rendered).to have_link("Add user", href: "/users/new")
+  end
+
+  it "renders the table headers" do
+    expect(rendered).to have_selector("th", text: "Name")
+    expect(rendered).to have_selector("th", text: "Email")
+  end
+
+  it "renders each user in the table" do
+    users.each do |user|
+      expect(rendered).to have_selector("td", text: user.name)
+      expect(rendered).to have_selector("td", text: user.email)
+    end
+  end
+
+  it "does not renders the pagination component" do
+    expect(rendered).not_to have_pagination
+  end
+
+  context "when pagy count is over 25" do
+    let(:count) {1_000_000}
+    it "calls page_data with govuk_number count" do
+      expect(view).to have_received(:page_data).with(title: "Support users (1,000,000)")
+    end
+    it "does renders the pagination component" do
+      expect(rendered).to have_pagination
+    end
+  end
+end

--- a/spec/views/users/new.html.erb_spec.rb
+++ b/spec/views/users/new.html.erb_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "users/new.html.erb", type: :view do
+  let(:user) { User.new }
+
+
+  before do
+    assign(:user, user)
+    allow(view).to receive(:page_data)
+
+    render
+  end
+
+  it "calls page_data" do
+    expect(view).to have_received(:page_data).with({error: false, header: false, title: "Add support user"})
+  end
+
+
+  it "renders the continue button" do
+    expect(rendered).to have_button("Continue")
+  end
+
+  it "renders the form" do
+    expect(rendered).to have_selector("form")
+    expect(rendered).to have_selector("input[name='user[first_name]']")
+    expect(rendered).to have_selector("input[name='user[last_name]']")
+    expect(rendered).to have_selector("input[name='user[email]']")
+  end
+
+  it "renders the cancel link" do
+    expect(rendered).to have_link("Cancel", href: users_path)
+  end
+  it "renders the back link" do
+    expect(view.content_for(:breadcrumbs)).to have_back_link(users_path)
+  end
+
+  context "with validation errors" do
+    let(:user) do
+      user = User.new
+      user.valid?
+      user
+    end
+
+    it "calls page_data with error" do
+      expect(view).to have_received(:page_data).with({error: true, header: false, title: "Add support user"})
+    end
+
+    it "renders the error summary" do
+      expect(view.content_for(:page_alerts)).to have_error_summary(
+        "Enter last name",
+        "Enter last name",
+        "Enter email address")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Add support user flow

### Changes proposed in this pull request
Added functionality to add user 

### Guidance to review
Journey begins here
https://register-training-providers-pr-77.test.teacherservices.cloud/users

- Click on `Add user` button
- Fill in `Personal details` form with invalid data
- Click on continue
- Review validations
- Correct invalid data
- Click on continue
- Review flash message

#### Out of scope 
 Check your answers page

#### Support users listing
With `Add user` button
![image](https://github.com/user-attachments/assets/bad06ace-c7d2-4936-b3b1-330840d01ec6)

##### Add support user page
![image](https://github.com/user-attachments/assets/2e1108f6-70d2-4c52-831e-ca48287dfcf9)

###### Validation 1
![image](https://github.com/user-attachments/assets/3dd77c8f-d441-4c17-80fe-08720578a75d)

###### Validation 2
![image](https://github.com/user-attachments/assets/c2824f1f-f66f-43bf-97b9-ce9562fe64af)

###### Validation 3
![image](https://github.com/user-attachments/assets/a5707f53-2fe8-493c-958e-5656967903cd)

#### Flash message
![image](https://github.com/user-attachments/assets/e7bbf705-27ea-4c3e-ac5b-6eb8730c3e1f)
