### PR TITLE
[0116] Amended initialiser for semantic logger to be more relaxed

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,9 +1,9 @@
-if Rails.env.development? || Rails.env.production?
+unless Rails.env.test?
   Rails.application.configure do
     config.log_tags = [ :request_id ] # Prepend all log lines with the following tags
   end
 
-  SemanticLogger.add_appender(io: $stdout, level: Rails.application.config.log_level, 
+  SemanticLogger.add_appender(io: $stdout, level: Rails.application.config.log_level,
     formatter: Rails.application.config.log_format)
   Rails.application.config.logger.info("Application logging to STDOUT")
 end


### PR DESCRIPTION
### Context
Semantic logger

### Changes proposed in this pull request
Amended initialiser for semantic logger to be more relaxed.

Previously it was only enabled on development and production.

### Guidance to review
:ship: 

Bypassing test as it generates a lot of noise