### PR TITLE
Enabling the scheduled prod db backup, adding probe path

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -22,11 +22,11 @@ on:
         description: |
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
 
-  # schedule:
-  #   - cron: "0 4 * * *" # 04:00 UTC
-  # change the backup time as required by the application
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC
 permissions:
   id-token: write
+  contents: write
 
 env:
   SERVICE_NAME: register-training-providers

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -29,7 +29,7 @@ module "web_application" {
   namespace    = var.namespace
   environment  = var.environment
   service_name = var.service_name
-  probe_path = null
+  probe_path = "/ping"
   replicas     = var.replicas
 
   cluster_configuration_map  = module.cluster_data.configuration_map


### PR DESCRIPTION
## Context
This new service Register of training providers to be onboarded with teacher service

## Changes proposed in this pull request
Enabling the scheduled prod db backup, adding probe path

## Guidance to review
Manual DB Backup
https://github.com/DFE-Digital/register-training-providers/actions/runs/15343051809
Scheduled DB Backup
TBD

## Link to Trello card
https://trello.com/c/Qs3GoLjP/2330-new-service-register-of-training-providers

## Checklist
- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [ ]  Tested by running locally