### PR TITLE
[0072] DfESsign-in setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,7 @@ SIGN_IN_METHOD=dfe-sign-in # Default, if not set
 # SIGN_IN_METHOD=persona # Default, for review apps
 # SIGN_IN_METHOD=otp # One time password, to be used when DfE Sign-In is unavailable
 
-DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk # URL that the users are redirected to for signing in
+DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk # DfE Sign-In ISSUER url, that the users are redirected to for signing in
+DFE_SIGN_IN_IDENTIFIER=rotp # DfE Sign-In IDENTIFIER, our service name
+DFE_SIGN_IN_SECRET=change_me # DfE Sign-In SECRET must be set otherwise sign in will fail
+DFE_SIGN_IN_PROFILE=https://test-profile.signin.education.gov.uk # DfE Sign-In PROFILE url, for the users profile

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-SIGN_IN_METHOD=dfe          # Default, if not set
-# SIGN_IN_METHOD=persona    # Default, for review apps
-# SIGN_IN_METHOD=otp        # One time password, to be used when DfE Sign-In is unavailable
+SIGN_IN_METHOD=dfe-sign-in # Default, if not set
+# SIGN_IN_METHOD=persona # Default, for review apps
+# SIGN_IN_METHOD=otp # One time password, to be used when DfE Sign-In is unavailable
 
 DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk # URL that the users are redirected to for signing in

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,5 @@
+SIGN_IN_METHOD=dfe-sign-in
 DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk
+DFE_SIGN_IN_IDENTIFIER=rotp
+DFE_SIGN_IN_SECRET=change_me
+DFE_SIGN_IN_PROFILE=https://test-profile.signin.education.gov.uk

--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -6,7 +6,7 @@ exclude:
   - test/**/*
   - vendor/**/*
   - ".bundle/**/*"
-require: []
+require: ["bundler"]
 domains: []
 reporters:
   - rubocop

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -2,5 +2,8 @@ class LandingPageController < ApplicationController
   skip_before_action :authenticate
 
   def start
+    if authenticated?
+      redirect_to providers_path
+    end
   end
 end

--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -1,0 +1,6 @@
+class SignOutController < ApplicationController
+  def index
+    DfESignInUser.end_session!(session)
+    redirect_to(sign_in_user.logout_url(request), allow_other_host: true)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(full_width_border: true, homepage_url: root_path) %>
+    <%= govuk_header(full_width_border: true, homepage_url: root_path, navigation_classes: "govuk-header__navigation--end") do |header|
+          header.with_navigation_item(text: "Sign out", href: sign_out_path, active: false) if @current_user.present?
+        end %>
 
     <%= govuk_service_navigation(
           service_name: t('service.name'),

--- a/config/initializers/omniauth/dfe_sign_in.rb
+++ b/config/initializers/omniauth/dfe_sign_in.rb
@@ -1,0 +1,35 @@
+if ENV["SIGN_IN_METHOD"] == "dfe-sign-in"
+
+  OmniAuth.config.logger = Rails.logger
+
+  issuer_uri = URI.parse(ENV["DFE_SIGN_IN_ISSUER"])
+  issuer_uri_with_port = "#{issuer_uri}:#{issuer_uri.port}" if issuer_uri.present?
+
+  SETUP_PROC = lambda do |env|
+    request = Rack::Request.new(env)
+
+    redirect_uri = URI.join(request.base_url, "/auth/dfe/callback")
+
+    env["omniauth.strategy"].options.client_options = {
+      port: issuer_uri.port,
+      scheme: issuer_uri.scheme,
+      host: issuer_uri.host,
+      identifier: ENV["DFE_SIGN_IN_IDENTIFIER"],
+      secret: ENV["DFE_SIGN_IN_SECRET"],
+      redirect_uri: redirect_uri,
+    }
+  end
+
+  Rails.application.config.middleware.use(OmniAuth::Builder) do
+    provider(:openid_connect, {
+      name: :dfe,
+      discovery: true,
+      scope: %i[email profile],
+      response_type: :code,
+      path_prefix: "/auth",
+      callback_path: "/auth/dfe/callback",
+      issuer: issuer_uri_with_port,
+      setup: SETUP_PROC,
+    })
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
   get "/sign-in/user-not-found", to: "sign_in#new"
 
   case Env.sign_in_method("dfe-sign-in")
+  when "dfe-sign-in"
+    get("/auth/dfe/callback" => "sessions#callback")
+    get("/auth/dfe/sign-out" => "sessions#signout")
   when "persona"
     get("/personas", to: "personas#index")
     get("/auth/developer/sign-out", to: "sessions#signout")

--- a/spec/features/end_to_end/sign_in_and_out_flow_spec.rb
+++ b/spec/features/end_to_end/sign_in_and_out_flow_spec.rb
@@ -13,11 +13,12 @@ RSpec.feature "Sign in and_out flow" do
     and_i_click_on("Support users")
     and_i_go_to_the_support_users_page
     and_i_click_on("Register of training providers")
-    and_i_am_take_to("/providers")
+    and_i_am_taken_to("/providers")
 
     when_i_click_on("Sign out")
-    then_i_am_signed_out
-    and_there_is_no_sign_out_link
+    then_i_logout_via_sso
+    and_i_am_taken_to("/")
+    and_i_am_not_signed_in
   end
 
   def given_i_am_on_the_start_page
@@ -32,12 +33,7 @@ RSpec.feature "Sign in and_out flow" do
     expect(page).to have_current_path("/users")
   end
 
-  def then_i_am_signed_out
-    simulate_external_sso_logout
-    then_i_am_take_to("/")
-  end
-
-  def simulate_external_sso_logout
+  def then_i_logout_via_sso
     # NOTE: 1, signs out via external sso
     expect(current_url).to start_with("https://test-oidc.signin.education.gov.uk/session/end")
     uri = URI.parse(current_url)
@@ -54,7 +50,7 @@ RSpec.feature "Sign in and_out flow" do
 
   def and_i_am_not_signed_in
     expect(page).to have_link("Sign in")
-    expect(page).not_to have_link("Sign out")
+    and_there_is_no_sign_out_link
   end
 
   def and_i_am_redirect_to_provider_page

--- a/spec/features/end_to_end/sign_in_and_out_flow_spec.rb
+++ b/spec/features/end_to_end/sign_in_and_out_flow_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.feature "Sign in and_out flow" do
+  scenario do
+    given_i_am_on_the_start_page
+    and_i_am_not_signed_in
+    and_there_is_no_sign_out_link
+    and_i_am_registered_as_a_user
+    and_i_have_a_dfe_sign_in_account
+    and_i_sign_in_via_dfe_sign_in
+
+    and_i_am_redirect_to_provider_page
+    and_i_click_on("Support users")
+    and_i_go_to_the_support_users_page
+    and_i_click_on("Register of training providers")
+    and_i_am_take_to("/providers")
+
+    when_i_click_on("Sign out")
+    then_i_am_signed_out
+    and_there_is_no_sign_out_link
+  end
+
+  def given_i_am_on_the_start_page
+    visit "/"
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    and_i_visit_the_sign_in_page
+  end
+
+  def and_i_go_to_the_support_users_page
+    expect(page).to have_current_path("/users")
+  end
+
+  def then_i_am_signed_out
+    simulate_external_sso_logout
+    then_i_am_take_to("/")
+  end
+
+  def simulate_external_sso_logout
+    # NOTE: 1, signs out via external sso
+    expect(current_url).to start_with("https://test-oidc.signin.education.gov.uk/session/end")
+    uri = URI.parse(current_url)
+    query = CGI.parse(uri.query)
+    expect(uri.path).to eq("/session/end")
+
+    # NOTE: 2, used the configured signout link
+    sign_out_link = "http://www.example.com/auth/dfe/sign-out"
+    expect(query["post_logout_redirect_uri"].first).to eq(sign_out_link)
+
+    # NOTE: 3, hand-off visit our sign out link afterwards
+    visit sign_out_link
+  end
+
+  def and_i_am_not_signed_in
+    expect(page).to have_link("Sign in")
+    expect(page).not_to have_link("Sign out")
+  end
+
+  def and_i_am_redirect_to_provider_page
+    expect(page).to have_current_path("/providers")
+  end
+
+  def and_there_is_no_sign_out_link
+    expect(page).not_to have_link("Sign out")
+  end
+end

--- a/spec/features/end_to_end/users/user_management_spec.rb
+++ b/spec/features/end_to_end/users/user_management_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "User management" do
   scenario "Users listing can be viewed" do
     given_i_am_an_authenticated_user
-    and_there_is_a_number_ot_support_users
+    and_there_are_a_number_of_support_users
     when_i_click_on_the_the_support_users_in_the_navigation_bar
     then_i_can_see_the_page_title_support_users_with_the_count
     and_a_table_of_support_users
@@ -14,7 +14,7 @@ RSpec.feature "User management" do
     click_link('Support users', class: 'govuk-service-navigation__link')
   end
 
-  def and_there_is_a_number_ot_support_users
+  def and_there_are_a_number_of_support_users
     users
   end
 

--- a/spec/features/end_to_end/users/user_management_spec.rb
+++ b/spec/features/end_to_end/users/user_management_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.feature "User management" do
+  scenario "Users listing can be viewed" do
+    given_i_am_an_authenticated_user
+    and_there_is_a_number_ot_support_users
+    when_i_click_on_the_the_support_users_in_the_navigation_bar
+    then_i_can_see_the_page_title_support_users_with_the_count
+    and_a_table_of_support_users
+    and_the_table_has_header_for_name_and_email
+  end
+
+  def when_i_click_on_the_the_support_users_in_the_navigation_bar
+    click_link('Support users', class: 'govuk-service-navigation__link')
+  end
+
+  def and_there_is_a_number_ot_support_users
+    users
+  end
+
+  def users
+    @users ||= create_list(:user, 24)
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    and_i_visit_the_sign_in_page
+  end
+
+  def then_i_can_see_the_page_title_support_users_with_the_count
+    expect(page).to have_title("Support users (25) - Register of training providers - GOV.UK")
+  end
+
+  def and_a_table_of_support_users
+    row_count = all('.govuk-table__body .govuk-table__row').count
+    expect(row_count).to eq(25)
+  end
+
+  def and_the_table_has_header_for_name_and_email
+    expect(page).to have_selector('.govuk-table__header', text: 'Name')
+    expect(page).to have_selector('.govuk-table__header', text: 'Email')
+  end
+end

--- a/spec/features/landing_page_spec.rb
+++ b/spec/features/landing_page_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "landing page" do
     and_i_should_see_the_service_name
     and_i_should_see_the_phase_banner
     when_i_click_on("Sign in")
-    then_i_am_take_to("/sign-in")
+    then_i_am_taken_to("/sign-in")
   end
 
   def given_i_am_on_the_start_page

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,8 +41,6 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
-  config.include NavigationHelpers, type: :feature
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :feature) do
+    config.include NavigationHelper
+  end
+end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,5 +1,7 @@
 RSpec.configure do |config|
   config.before(:each, type: :feature) do
     config.include NavigationHelper
+    config.include DfESignInUserHelper
+    config.include AuthenticationHelper
   end
 end

--- a/spec/support/features/authentication_helper.rb
+++ b/spec/support/features/authentication_helper.rb
@@ -1,0 +1,29 @@
+module AuthenticationHelper
+  def given_i_am_authenticated(user: nil)
+    @current_user = user if user.present?
+    user_exists_in_dfe_sign_in(user: current_user)
+
+    and_i_visit_the_sign_in_page
+  end
+
+  def given_i_am_an_authenticated_user
+    given_i_am_authenticated
+  end
+
+  def and_i_visit_the_sign_in_page
+    visit "/sign-in"
+    and_i_click_on("Sign in using DfE Sign-in")
+  end
+
+  def and_i_have_a_dfe_sign_in_account
+    user_exists_in_dfe_sign_in(user: @current_user)
+  end
+
+  def current_user
+    @current_user ||= create(:user)
+  end
+
+  def and_i_am_registered_as_a_user
+    current_user
+  end
+end

--- a/spec/support/features/dfe_sign_in_user_helper.rb
+++ b/spec/support/features/dfe_sign_in_user_helper.rb
@@ -1,0 +1,45 @@
+module DfESignInUserHelper
+  def user_exists_in_dfe_sign_in(user:)
+    OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+      fake_dfe_sign_in_auth_hash(
+        email: user.email,
+        dfe_sign_in_uid: user.dfe_sign_in_uid,
+        first_name: user.first_name,
+        last_name: user.last_name,
+      ),
+    )
+  end
+
+private
+
+  def fake_dfe_sign_in_auth_hash(email:, dfe_sign_in_uid:, first_name:, last_name:)
+    {
+      "provider" => "dfe",
+      "uid" => dfe_sign_in_uid,
+      "info" => {
+        "name" => "#{first_name} #{last_name}",
+        "email" => email,
+        "nickname" => nil,
+        "first_name" => first_name,
+        "last_name" => last_name,
+        "gender" => nil,
+        "image" => nil,
+        "phone" => nil,
+        "urls" => { "website" => nil },
+      },
+      "credentials" => {
+        "id_token" => "id_token",
+        "token" => "DFE_SIGN_IN_TOKEN",
+        "refresh_token" => nil,
+        "expires_in" => 3600,
+        "scope" => "email openid",
+      },
+      "extra" => {
+        "raw_info" => {
+          "email" => email,
+          "sub" => dfe_sign_in_uid,
+        },
+      },
+    }
+  end
+end

--- a/spec/support/features/navigation_helper.rb
+++ b/spec/support/features/navigation_helper.rb
@@ -1,5 +1,5 @@
 module NavigationHelper
-  def then_i_am_take_to(path)
+  def then_i_am_taken_to(path)
     expect(page).to have_current_path(path)
   end
 
@@ -8,5 +8,5 @@ module NavigationHelper
   end
 
   alias_method :and_i_click_on, :when_i_click_on
-  alias_method :and_i_am_take_to, :then_i_am_take_to
+  alias_method :and_i_am_taken_to, :then_i_am_taken_to
 end

--- a/spec/support/features/navigation_helper.rb
+++ b/spec/support/features/navigation_helper.rb
@@ -1,4 +1,4 @@
-module NavigationHelpers
+module NavigationHelper
   def then_i_am_take_to(path)
     expect(page).to have_current_path(path)
   end
@@ -6,4 +6,7 @@ module NavigationHelpers
   def when_i_click_on(button_or_link)
     page.click_on(button_or_link)
   end
+
+  alias_method :and_i_click_on, :when_i_click_on
+  alias_method :and_i_am_take_to, :then_i_am_take_to
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,1 @@
+OmniAuth.config.test_mode = true


### PR DESCRIPTION
### Context
DfE Sign-in and the related user sign in/out process

### Changes proposed in this pull request
Added the reminder of the dfe sign in expected configuration
Added the sign out link/process
Amended landing page to redirect if authenticated

### Guidance to review
- The features specs
- The sign out link
![image](https://github.com/user-attachments/assets/0b75f6be-bbf6-40e3-99bf-3d28650f7eee)


The sign in and sign out completion was needed as they based on actual `dfe` onimauth strategy
- in it absences it was making feature specs a no go
-  as  `persona`/`developer`/`test user` onimauth strategy has no real value to be embed in testing

Out of scope
-  actually working of DfE Sign-in, as it currently being onboarded. 

When actual configuration is available it should just work.

