### PR TITLE
[0079] Add support user flow with check answer page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,5 +74,6 @@ Layout/TrailingEmptyLines:
 
 Layout/LineLength:
   Exclude:
+    - "spec/**/*.rb"
     - "app/views/**/*.erb"
     - "app/components/**/*.erb"

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -47,11 +47,11 @@ private
   end
 
   def new_model_path
-    url_for([:new, model_name.to_sym])
+    @new_model_path ||= url_for([:new, model_name.to_sym])
   end
 
   def success_path
-    url_for([model_name_pluralized.to_sym])
+    @success_path ||= url_for([model_name_pluralized.to_sym])
   end
 
   def save_path
@@ -59,7 +59,7 @@ private
   end
 
   def new_model_check_path
-    url_for([model_name.to_sym, :confirm])
+    @new_model_check_path ||= url_for([model_name.to_sym, :confirm])
   end
 
   def rows

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -1,0 +1,72 @@
+class CheckController < ApplicationController
+  def new
+    if model.invalid?
+      redirect_to new_model_path
+    end
+
+    save_path
+    model
+    rows
+  end
+
+  def create
+    if model.save
+
+      redirect_to success_path, flash: flash_message
+    else
+      # NOTE: if it failed there is something really wrong send them back to the form
+      # and let them trigger the validation again
+      redirect_to new_model_path
+    end
+  end
+
+private
+
+  def flash_message
+    { success: I18n.t("flash_message.success.check.#{model_name}.#{mode}") }
+  end
+
+  def mode
+    model.persisted? ? "add" : "update"
+  end
+
+  def model
+    @model ||= current_user.load_temporary(model_class, purpose: :check_your_answers)
+  end
+
+  def model_class
+    controller_path.split("/").first.classify.constantize
+  end
+
+  def model_name
+    model_class.name.underscore
+  end
+
+  def model_name_pluralized
+    model_name.pluralize
+  end
+
+  def new_model_path
+    url_for([:new, model_name.to_sym])
+  end
+
+  def success_path
+    url_for([model_name_pluralized.to_sym])
+  end
+
+  def save_path
+    @save_path ||= new_model_check_path
+  end
+
+  def new_model_check_path
+    url_for([model_name.to_sym, :confirm])
+  end
+
+  def rows
+    @rows = generate_rows
+  end
+
+  def generate_rows
+    raise NotImplementedError
+  end
+end

--- a/app/controllers/users/check_controller.rb
+++ b/app/controllers/users/check_controller.rb
@@ -1,9 +1,15 @@
 class Users::CheckController < CheckController
   def generate_rows
     [
-      { key: { text: "First name" }, value: { text: model.first_name } },
-      { key: { text: "Last name" }, value: { text: model.last_name } },
-      { key: { text: "Email address" }, value: { text: model.email } },
+      { key: { text: "First name" },
+        value: { text: model.first_name },
+        actions: [{ href: new_model_path, visually_hidden_text: "first name" }] },
+      { key: { text: "Last name" },
+        value: { text: model.last_name },
+        actions: [{ href: new_model_path, visually_hidden_text: "last name" }] },
+      { key: { text: "Email address" },
+        value: { text: model.email },
+        actions: [{ href: new_model_path, visually_hidden_text: "email address" }] },
     ]
   end
 end

--- a/app/controllers/users/check_controller.rb
+++ b/app/controllers/users/check_controller.rb
@@ -1,0 +1,9 @@
+class Users::CheckController < CheckController
+  def generate_rows
+    [
+      { key: { text: "First name" }, value: { text: model.first_name } },
+      { key: { text: "Last name" }, value: { text: model.last_name } },
+      { key: { text: "Email address" }, value: { text: model.email } },
+    ]
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(params.expect(user: [:first_name, :last_name, :email]))
     if @user.valid?
-      redirect_to new_user_check_path
+      redirect_to new_user_confirm_path
     else
       render(:new)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,9 +12,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(params.expect(user: [:first_name, :last_name, :email]))
     if @user.valid?
-      @user.save!
-
-      redirect_to users_path, flash: { success: "Support user added" }
+      redirect_to new_user_check_path
     else
       render(:new)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,16 +2,18 @@ class UsersController < ApplicationController
   include Pagy::Backend
 
   def index
+    current_user.clear_temporary(User, purpose: :check_your_answers)
     @pagy, @records = pagy(User.kept.order_by_first_then_last_name)
   end
 
   def new
-    @user = User.new
+    @user = current_user.load_temporary(User, purpose: :check_your_answers)
   end
 
   def create
     @user = User.new(params.expect(user: [:first_name, :last_name, :email]))
     if @user.valid?
+      @user.save_as_temporary!(created_by: current_user, purpose: :check_your_answers)
       redirect_to new_user_confirm_path
     else
       render(:new)

--- a/app/views/users/check/new.html.erb
+++ b/app/views/users/check/new.html.erb
@@ -1,0 +1,4 @@
+<%= render CheckYourAnswers::View.new(
+      rows: @rows, subtitle: "Add support user", caption: "Add support user", back_path: new_user_path,
+      save_button_text: "Save user", save_path: @save_path, cancel_path: users_path
+    ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,3 +37,8 @@ en:
           invalid: Enter a Department for Education email address in the correct format, like name@education.gov.uk
         email:
           invalid: Enter an email address in the correct format, like name@example.com
+  flash_message:
+    success:
+      check:
+        user:
+          add: "Support user added"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,13 @@
 Rails.application.routes.draw do
+  def checkable(model)
+    collection do
+      scope module: model do
+        resource :check, only: %i[new create], path: "/check", as: "#{model.to_s.singularize}_confirm",
+                         controller: "check"
+      end
+    end
+  end
+
   root to: "landing_page#start"
 
   get :ping, controller: :heartbeat
@@ -27,5 +36,8 @@ Rails.application.routes.draw do
   end
 
   resources :providers, only: %i[index]
-  resources :users, only: %i[index new create]
+
+  resources :users, only: %i[index new create] do
+    checkable(:users)
+  end
 end

--- a/spec/components/check_your_answers/view_preview.rb
+++ b/spec/components/check_your_answers/view_preview.rb
@@ -15,9 +15,9 @@ module CheckYourAnswers
 
     def rows
       [
-        { key: { text: "First name" }, value: { text: new_user.first_name } },
-        { key: { text: "Last name" }, value: { text: new_user.last_name } },
-        { key: { text: "Email address" }, value: { text: new_user.email } },
+        { key: { text: "First name" }, value: { text: new_user.first_name }, actions: [{ href: new_user_path }] },
+        { key: { text: "Last name" }, value: { text: new_user.last_name }, actions: [{ href: new_user_path }] },
+        { key: { text: "Email address" }, value: { text: new_user.email }, actions: [{ href: new_user_path }] },
       ]
     end
 

--- a/spec/features/end_to_end/users/creating_user_spec.rb
+++ b/spec/features/end_to_end/users/creating_user_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.feature "User management" do
+  scenario "creating users" do
+    given_i_am_an_authenticated_user
+    and_i_am_on_the_user_support_listing_page
+    and_i_can_see_the_page_title_support_users_with_the_count
+    and_i_click_on("Add user")
+    and_i_am_taken_to("/users/new")
+    and_i_can_see_the_page_title_for_personal_details
+    and_i_do_not_see_error_summary
+
+    and_i_click_on("Continue")
+    and_i_can_see_the_error_summary
+    and_i_can_see_the_page_title_for_personal_details_with_error
+
+    and_i_fill_in_the_personal_details_correctly
+    and_i_click_on("Continue")
+    and_i_am_taken_to("/users/check/new")
+    and_i_can_see_the_page_title_for_check_your_answers
+    when_i_click_on("Save user")
+    and_i_am_taken_to("/users")
+
+    then_i_see_the_success_message
+    and_i_can_see_the_page_title_support_users_with_the_count(count: 2)
+  end
+
+  def and_i_can_see_the_page_title_support_users_with_the_count(count: 1)
+    expect(page).to have_title("Support users (#{count}) - Register of training providers - GOV.UK")
+  end
+
+  def and_i_am_on_the_user_support_listing_page
+    visit "/users"
+  end
+
+  def user
+    @user ||= build(:user)
+  end
+
+  def then_i_see_the_success_message
+    expect(page).to have_notification_banner("Success", "Support user added")
+  end
+
+  def and_i_can_see_the_page_title_for_check_your_answers
+    expect(page).to have_title("Check your answers - Add support user - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_personal_details_with_error
+    expect(page).to have_title("Error: Add support user - personal details - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_personal_details
+    expect(page).to have_title("Add support user - personal details - Register of training providers - GOV.UK")
+  end
+
+  def and_i_do_not_see_error_summary
+    expect(page).not_to have_error_summary
+  end
+
+  def and_i_can_see_the_error_summary
+    expect(page).to have_error_summary(
+      "Enter last name",
+      "Enter last name",
+      "Enter email address"
+    )
+  end
+
+  def and_i_fill_in_the_personal_details_correctly
+    page.fill_in "First name", with: user.first_name
+    page.fill_in "Last name", with: user.first_name
+    page.fill_in "Email", with: user.email
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     let(:header) { nil }
     let(:header_size) { "l" }
     let(:error) { false }
+    let(:caption) { nil }
 
     subject(:result) do
       helper.page_data(title: title, header: header, header_size: header_size, error: error, caption: caption)
@@ -37,8 +38,21 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "returns page_title and page_header" do
       expect(result[:page_title]).to eq("Larry Page")
       expect(result[:page_header]).to include("govuk-heading-l")
+      expect(result[:page_header]).to include("Larry Page")
+      expect(result[:page_header]).not_to include("govuk-caption-l")
+      expect(result[:page_header]).not_to include("Caption")
     end
 
+    context "when caption is set" do
+      let(:caption) { "Caption" }
+      it "returns page_title and page_header" do
+        expect(result[:page_title]).to eq("Larry Page")
+        expect(result[:page_header]).to include("govuk-heading-l")
+        expect(result[:page_header]).to include("Larry Page")
+        expect(result[:page_header]).to include("govuk-caption-l")
+        expect(result[:page_header]).to include("Caption")
+      end
+    end
     context "when error is true" do
       let(:error) { true }
 

--- a/spec/support/features/matchers/notification_banner_matcher.rb
+++ b/spec/support/features/matchers/notification_banner_matcher.rb
@@ -1,11 +1,10 @@
 RSpec::Matchers.define :have_notification_banner do |expected_title, expected_content|
   match do |page|
-    element = page.find(".govuk-notification-banner", text: expected_title)
-    expect(element).not_to be_nil
-    within element do
-      content_element = find(".govuk-heading-m", text: expected_content)
-      expect(content_element).to be_visible
-    end
+    banner = page.find(".govuk-notification-banner")
+    expect(banner).not_to be_nil
+
+    expect(banner).to have_css(".govuk-notification-banner__header", text: expected_title)
+    expect(banner).to have_css(".govuk-notification-banner__content", text: expected_content)
   end
 
   failure_message do |_page|

--- a/spec/support/features/matchers/notification_banner_matcher.rb
+++ b/spec/support/features/matchers/notification_banner_matcher.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :have_notification_banner do |expected_title, expected_content|
+  match do |page|
+    element = page.find(".govuk-notification-banner", text: expected_title)
+    expect(element).not_to be_nil
+    within element do
+      content_element = find(".govuk-heading-m", text: expected_content)
+      expect(content_element).to be_visible
+    end
+  end
+
+  failure_message do |_page|
+    "expected to find a notification banner with title '#{expected_title}' and content '#{expected_content}', but it was not found."
+  end
+
+  failure_message_when_negated do |_page|
+    "expected not to find a notification banner with title '#{expected_title}' and content '#{expected_content}', but it was found."
+  end
+end


### PR DESCRIPTION
### Context
The add a support user flow, with check your answers.

### Changes proposed in this pull request
The check your answers, will replay the previously saved captured from the previous form.
Landing on the user listing page, via nature traversing or via `cancel`/`back` will have any previous temporary record of that user cleared.
There is a daily scheduled task to clear expired temporary record.
Caption/page title is aligned with [design history}(https://becoming-a-teacher.design-history.education.gov.uk/register-of-training-providers/how-we-use-heading-captions/#include-captions-in-the-page-title)




### Guidance to review
The temporary record is cleared on the user listing page, regardless, this enable no tracking of where user have transverse.

This is mainly a workflow for `Check your answers` there is a number of cross with other items that we will be capture, of which all will  exhibit the same behaviour and workflow.

1 On the Listing page, there is a call to action
2 Add a `item` button
3 A page with a form to capture the item concerned
4 Check your answers page
5 On the Listing page, with a flash message

Going to the Check your answers page directly without temporary record will redirect to the new user page.
