### PR TITLE
[0079] Add solid queue

### DIFF
--- a/.erdconfig
+++ b/.erdconfig
@@ -4,7 +4,22 @@ attributes:
   - content
   - foreign_key
   - inheritance
-exclude: "ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, primary::SchemaMigration, Persona"
+exclude:
+  - ActiveRecord::SchemaMigration
+  - ActiveRecord::InternalMetadata
+  - primary::SchemaMigration
+  - Persona
+  - SolidQueue::BlockedExecution
+  - SolidQueue::ClaimedExecution
+  - SolidQueue::FailedExecution
+  - SolidQueue::Job
+  - SolidQueue::Pause
+  - SolidQueue::Process
+  - SolidQueue::ReadyExecution
+  - SolidQueue::RecurringExecution
+  - SolidQueue::RecurringTask
+  - SolidQueue::ScheduledExecution
+  - SolidQueue::Semaphore
 filename: docs/database-diagram
 filetype: jpg
 title: Register of training providers database diagram

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,5 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
-CMD ["sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"]
+ENTRYPOINT ["./bin/rails", "server"]
+CMD ["-b", "0.0.0.0"]

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
-css: yarn build:css --watch
-js: yarn build --watch
+web:    env RUBY_DEBUG_OPEN=true bin/rails server
+css:    yarn build:css --watch
+js:     yarn build --watch
+worker: env RUBY_DEBUG_OPEN=true bin/rails solid_queue:start

--- a/app/jobs/demo_job.rb
+++ b/app/jobs/demo_job.rb
@@ -1,0 +1,7 @@
+class DemoJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Rails.logger.info "[#{Time.current}] Running scheduled DemoJob with #{args.inspect}"
+  end
+end

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,7 @@ module RegisterTrainingProviders
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/view_components"
     config.view_component.show_previews = !Rails.env.production?
+
+    config.active_job.queue_adapter = :solid_queue
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do # Semantic logging for integration with Kibana
   # config.cache_store = :mem_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  # config.active_job.queue_adapter = :resque
+  config.active_job.queue_adapter = :solid_queue
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,10 @@
+# production:
+#   periodic_cleanup:
+#     class: CleanSoftDeletedRecordsJob
+#     queue: background
+#     args: [ 1000, { batch_size: 500 } ]
+#     schedule: every hour
+#   periodic_command:
+#     command: "SoftDeletedRecord.due.delete_all"
+#     priority: 2
+#     schedule: at 5am every day

--- a/db/migrate/20250617085424_add_solid_queue.rb
+++ b/db/migrate/20250617085424_add_solid_queue.rb
@@ -1,0 +1,132 @@
+class AddSolidQueue < ActiveRecord::Migration[8.0]
+  def change
+    create_table "solid_queue_blocked_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "queue_name", null: false
+      t.integer "priority", default: 0, null: false
+      t.string "concurrency_key", null: false
+      t.datetime "expires_at", null: false
+      t.datetime "created_at", null: false
+      t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+      t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+      t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    end
+
+    create_table "solid_queue_claimed_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.bigint "process_id"
+      t.datetime "created_at", null: false
+      t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+      t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    end
+
+    create_table "solid_queue_failed_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.text "error"
+      t.datetime "created_at", null: false
+      t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    end
+
+    create_table "solid_queue_jobs", force: :cascade do |t|
+      t.string "queue_name", null: false
+      t.string "class_name", null: false
+      t.text "arguments"
+      t.integer "priority", default: 0, null: false
+      t.string "active_job_id"
+      t.datetime "scheduled_at"
+      t.datetime "finished_at"
+      t.string "concurrency_key"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+      t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+      t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+      t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+      t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table "solid_queue_pauses", force: :cascade do |t|
+      t.string "queue_name", null: false
+      t.datetime "created_at", null: false
+      t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    end
+
+    create_table "solid_queue_processes", force: :cascade do |t|
+      t.string "kind", null: false
+      t.datetime "last_heartbeat_at", null: false
+      t.bigint "supervisor_id"
+      t.integer "pid", null: false
+      t.string "hostname"
+      t.text "metadata"
+      t.datetime "created_at", null: false
+      t.string "name", null: false
+      t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+      t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+      t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+    end
+
+    create_table "solid_queue_ready_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "queue_name", null: false
+      t.integer "priority", default: 0, null: false
+      t.datetime "created_at", null: false
+      t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+      t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+      t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table "solid_queue_recurring_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "task_key", null: false
+      t.datetime "run_at", null: false
+      t.datetime "created_at", null: false
+      t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+      t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at",
+                                      unique: true
+    end
+
+    create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+      t.string "key", null: false
+      t.string "schedule", null: false
+      t.string "command", limit: 2048
+      t.string "class_name"
+      t.text "arguments"
+      t.string "queue_name"
+      t.integer "priority", default: 0
+      t.boolean "static", default: true, null: false
+      t.text "description"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+      t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+    end
+
+    create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "queue_name", null: false
+      t.integer "priority", default: 0, null: false
+      t.datetime "scheduled_at", null: false
+      t.datetime "created_at", null: false
+      t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+      t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table "solid_queue_semaphores", force: :cascade do |t|
+      t.string "key", null: false
+      t.integer "value", default: 1, null: false
+      t.datetime "expires_at", null: false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+      t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+      t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+    end
+
+    add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_12_144352) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_17_085424) do
   # These are extensions that must be enabled in order to support this database
 
   create_table "audits", force: :cascade do |t|
@@ -35,6 +35,127 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_12_144352) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "dfe_sign_in_uid"
     t.string "email", null: false
@@ -47,4 +168,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_12_144352) do
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/spec/jobs/demo_job_spec.rb
+++ b/spec/jobs/demo_job_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe DemoJob, type: :job do
+  it "enqueues the job" do
+    expect {
+      DemoJob.perform_later("test")
+    }.to have_enqueued_job(DemoJob).with("test")
+  end
+end

--- a/spec/support/job.rb
+++ b/spec/support/job.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :job) do
+    ActiveJob::Base.queue_adapter = :test
+  end
+end

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -21,6 +21,23 @@ module "application_configuration" {
   }
 }
 
+module "migration" {
+  source = "./vendor/modules/aks//aks/job_configuration"
+
+  namespace    = var.namespace
+  environment  = var.environment
+  service_name = var.service_name
+  docker_image = var.docker_image
+  commands     = var.commands
+  arguments    = var.arguments
+  job_name     = var.job_name
+  enable_logit = true
+
+  config_map_ref = module.application_configuration.kubernetes_config_map_name
+  secret_ref     = module.application_configuration.kubernetes_secret_name
+  cpu            = module.cluster_data.configuration_map.cpu_min
+}
+
 module "web_application" {
   source = "./vendor/modules/aks//aks/application"
 

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -40,6 +40,7 @@ module "migration" {
 
 module "web_application" {
   source = "./vendor/modules/aks//aks/application"
+  depends_on = [module.migration]
 
   is_web = true
 
@@ -61,6 +62,7 @@ module "web_application" {
 
 module "worker_application" {
   source     = "./vendor/modules/aks//aks/application"
+  depends_on = [module.migration]
 
   is_web = false
 

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -58,3 +58,28 @@ module "web_application" {
 
   send_traffic_to_maintenance_page = var.send_traffic_to_maintenance_page
 }
+
+module "worker_application" {
+  source     = "./vendor/modules/aks//aks/application"
+
+  is_web = false
+
+  name         = "worker"
+  namespace    = var.namespace
+  environment  = var.environment
+  service_name = var.service_name
+
+  cluster_configuration_map  = module.cluster_data.configuration_map
+  kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
+  kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
+
+  docker_image = var.docker_image
+
+  command       = ["bundle", "exec", "rake", "solid_queue:start"]
+  probe_command = ["pgrep", "-f", "solid-queue-worker"]
+
+  replicas   = var.worker_replicas
+  max_memory = var.worker_memory_max
+
+  enable_logit   = true
+}

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -98,3 +98,21 @@ variable "postgres_enable_high_availability" {
   default = false
 }
 
+variable "commands" {
+  description = "list of required docker image commands for k8s job to run"
+  type        = list(string)
+  default     = ["bundle"]
+}
+
+variable "arguments" {
+  description = "list of required docker image arguments for k8s job to run"
+  type        = list(string)
+  default     = ["exec", "rails", "db:prepare"]
+}
+
+variable "job_name" {
+  description = "name of the k8s job to run"
+  type        = string
+  default     = "migrations"
+}
+

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -98,6 +98,16 @@ variable "postgres_enable_high_availability" {
   default = false
 }
 
+variable "worker_memory_max" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "worker_replicas" {
+  type = number
+  default = 1
+}
+
 variable "commands" {
   description = "list of required docker image commands for k8s job to run"
   type        = list(string)


### PR DESCRIPTION
### Context
Solid queue

### Changes proposed in this pull request
Add solid queue
Add worker

### Guidance to review
https://github.com/rails/solid_queue/?tab=readme-ov-file#single-database-configuration


#### Full instructions

1. You need the worker

```bash
bin/rails solid_queue:start
```

2. You need to drop in
```bash
bin/rails rails console
```

3. You need to enqueue
```ruby
DemoJob.set(wait: 10.seconds).perform_later("foo")
```

4. Then check on `finished_at`
```ruby
SolidQueue::Job.last
```

For local, you can substitute 1 & 2 with  
```bash
bin/dev
```
For review app, you can skip 1 and just ssh onto the box

This commit to be dropped before merge
https://github.com/DFE-Digital/register-training-providers/pull/96/commits/462453fc3e878dff7e470339a167c91495558ab5

