### PR TITLE
[0080] Added view support user page

### DIFF
--- a/app/components/user_summary/view.rb
+++ b/app/components/user_summary/view.rb
@@ -18,13 +18,13 @@ module UserSummary
       [
         { key: { text: "First name" },
           value: { text: @user.first_name },
-          actions: editable ? [{ href: "#", visually_hidden_text: "first name" }] : [] },
+          actions: editable ? [{ href: edit_user_path(user), visually_hidden_text: "first name" }] : [] },
         { key: { text: "Last name" },
           value: { text: @user.last_name },
-          actions: editable ? [{ href: "#", visually_hidden_text: "last name" }] : [] },
+          actions: editable ? [{ href: edit_user_path(user), visually_hidden_text: "last name" }] : [] },
         { key: { text: "Email address" },
           value: { text: @user.email },
-          actions: editable ? [{ href: "#", visually_hidden_text: "email address" }] : [] },
+          actions: editable ? [{ href: edit_user_path(user), visually_hidden_text: "email address" }] : [] },
       ]
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,10 @@ class UsersController < ApplicationController
     @pagy, @records = pagy(User.kept.order_by_first_then_last_name)
   end
 
+  def show
+    @user = User.find(params[:id])
+  end
+
   def new
     @user = current_user.load_temporary(User, purpose: :check_your_answers)
   end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -12,7 +12,7 @@
       table.with_body do |body|
         @records.each do |user|
           body.with_row do |row|
-            row.with_cell(text: user.name)
+            row.with_cell(text: govuk_link_to(user.name, href: user_path(user)))
             row.with_cell(text: user.email)
           end
         end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,4 @@
+<%= render UserSummary::View.new(
+      title: "View support user", caption: "Support user", back_path: users_path,
+      delete_path: @current_user == @user ? nil : user_delete_path(@user), editable: @current_user != @user, user: @user
+    ) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   resources :providers, only: %i[index]
 
-  resources :users, only: %i[index new create] do
+  resources :users, only: %i[index new create show] do
     checkable(:users)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,8 @@ Rails.application.routes.draw do
 
   resources :providers, only: %i[index]
 
-  resources :users, only: %i[index new create show] do
+  resources :users, only: %i[index new create show edit] do
     checkable(:users)
+    resource :delete, only: [:show, :destroy], module: :users
   end
 end

--- a/spec/components/user_summary/view_spec.rb
+++ b/spec/components/user_summary/view_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe UserSummary::View, type: :component do
   describe "preview" do
     let(:expected_summary_rows) do
       [
-        { label: "First name", value: user.first_name, link_text: "Change first name", href: "#" },
-        { label: "Last name", value: user.last_name, link_text: "Change last name", href: "#" },
-        { label: "Email address", value: user.email, link_text: "Change email address", href: "#" }
+        { label: "First name", value: user.first_name, link_text: "Change first name", href: "/users/#{user.id}/edit" },
+        { label: "Last name", value: user.last_name, link_text: "Change last name", href: "/users/#{user.id}/edit" },
+        { label: "Email address", value: user.email, link_text: "Change email address", href: "/users/#{user.id}/edit" }
       ]
     end
 

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "users/index.html.erb", type: :view do
 
   it "renders each user in the table" do
     users.each do |user|
-      expect(rendered).to have_selector("td", text: user.name)
+      expect(rendered).to have_link(user.name, href: user_path(user))
       expect(rendered).to have_selector("td", text: user.email)
     end
   end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     end
 
     trait :math_magician do
+      id { 42 }
       first_name { "Mathilda" }
       last_name { "Mathmagician" }
     end


### PR DESCRIPTION
### Context
The view support user page

### Changes proposed in this pull request
Added the view support user page
### Guidance to review

This is where the page starts to have two call to action
- delete user
- edit user

Both covered elsewhere

Does the page look right?

#### Viewing someone else
![image](https://github.com/user-attachments/assets/f2322e42-743d-47a7-9f7a-8c1116ef0f68)

#### Viewing self
![image](https://github.com/user-attachments/assets/beef1399-e959-4d7b-8495-b57f6125ba02)
