### PR TITLE
[0082] Added the change support user details flow

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -8,7 +8,7 @@ linters:
   ErbSafety:
     enabled: true
   StrictLocals:
-    enabled: true
+    enabled: false
   Rubocop:
     enabled: true
     rubocop_config:

--- a/app/components/check_your_answers/view.html.erb
+++ b/app/components/check_your_answers/view.html.erb
@@ -2,11 +2,11 @@
   <%= govuk_back_link(text: "Back", href: back_path) %>
 <% end %>
 
-<% page_data(title: title, subtitle: subtitle, caption: caption) %>
+<% page_data(title:, subtitle:, caption:, header:) %>
 
 <%= govuk_summary_list(rows: rows) %>
 
-<%= govuk_button_to(save_button_text, save_path) %>
+<%= govuk_button_to(save_button_text, save_path, method:) %>
 
 <p class="govuk-body">
   <%= govuk_link_to("Cancel", cancel_path) %>

--- a/app/components/check_your_answers/view.rb
+++ b/app/components/check_your_answers/view.rb
@@ -1,10 +1,11 @@
 module CheckYourAnswers
   class View < ViewComponent::Base
     include ApplicationHelper
-    attr_reader :rows, :title, :subtitle, :caption, :back_path, :save_button_text, :save_path, :cancel_path
+    attr_reader :rows, :title, :subtitle, :caption, :back_path, :save_button_text, :save_path, :cancel_path, :method,
+                :header
 
-    def initialize(rows:, subtitle:, caption:, back_path:, save_button_text:, save_path:, cancel_path:,
-                   title: "Check your answers")
+    def initialize(rows:, caption:, back_path:, save_button_text:, save_path:, cancel_path:, method:, subtitle: nil,
+                   header: "Check your answers", title: "Check your answers")
       @rows = rows
       @subtitle = subtitle
       @caption = caption
@@ -13,6 +14,8 @@ module CheckYourAnswers
       @save_path = save_path
       @cancel_path = cancel_path
       @title = title
+      @header = header
+      @method = method
       super
     end
   end

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -1,5 +1,5 @@
 class CheckController < ApplicationController
-  helper_method :rows, :save_path, :back_path, :cancel_path, :method
+  helper_method :rows, :save_path, :back_path, :cancel_path, :method, :model
 
   def show
     redirect_to back_path if model.invalid?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,15 +3,20 @@ class UsersController < ApplicationController
 
   def index
     current_user.clear_temporary(User, purpose: :check_your_answers)
+
     @pagy, @records = pagy(User.kept.order_by_first_then_last_name)
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.find(id)
   end
 
   def new
     @user = current_user.load_temporary(User, purpose: :check_your_answers)
+  end
+
+  def edit
+    @user = current_user.load_temporary(User, id: id, purpose: :check_your_answers)
   end
 
   def create
@@ -22,5 +27,22 @@ class UsersController < ApplicationController
     else
       render(:new)
     end
+  end
+
+  def update
+    @user = current_user.load_temporary(User, id: id, purpose: :check_your_answers)
+
+    @user.assign_attributes(params.expect(user: [:first_name, :last_name, :email]))
+
+    if @user.valid?
+      @user.save_as_temporary!(created_by: current_user, purpose: :check_your_answers)
+      redirect_to user_check_path(@user)
+    else
+      render(:edit)
+    end
+  end
+
+  def id
+    params[:id].to_i
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
-  def load_temporary(record_class, purpose:, reset: false)
+  def load_temporary(record_class, purpose:, id: nil, reset: false)
     clear_temporary(record_class, purpose:) if reset
 
     record_type = record_class.name
@@ -53,7 +53,13 @@ class User < ApplicationRecord
       return record_class.new
     end
 
-    record&.rehydrate || record_class.new
+    if id.present?
+      existing_record = record_class.find(id)
+      existing_record.assign_attributes(record.rehydrate.attributes.except("id")) if record.present?
+      existing_record
+    else
+      record&.rehydrate || record_class.new
+    end
   end
 
   def clear_temporary(record_class, purpose:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,9 @@ class User < ApplicationRecord
   scope :order_by_first_then_last_name, -> { order(:first_name, :last_name) }
 
   def name
-    "#{first_name} #{last_name}"
+    first_name_to_use = first_name_was || first_name
+    last_name_to_use = last_name_was || last_name
+    "#{first_name_to_use} #{last_name_to_use}"
   end
 
   def load_temporary(record_class, purpose:, id: nil, reset: false)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,8 +36,8 @@
           service_url: root_path,
           current_path: request.path,
           navigation_items: [
-            { text: "Providers", href: providers_path },
-            { text: "Support users", href: users_path },
+            { text: "Providers", href: providers_path, active_when: providers_path },
+            { text: "Support users", href: users_path, active_when: users_path },
           ]
         ) if @current_user.present? %>
 

--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -1,0 +1,4 @@
+<%= form.govuk_text_field :first_name, width: "two-thirds", label: { size: "s", text: "First name" } %>
+<%= form.govuk_text_field :last_name, width: "two-thirds", label: { size: "s", text: "Last name" } %>
+<%= form.govuk_text_field :email, width: "full", label: { size: "s", text: "Email address" },
+                                  hint: { text: "Email must be a valid Department for Education address, like name@education.gov.uk" } %>

--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -1,4 +1,4 @@
 <%= form.govuk_text_field :first_name, width: "two-thirds", label: { size: "s", text: "First name" } %>
 <%= form.govuk_text_field :last_name, width: "two-thirds", label: { size: "s", text: "Last name" } %>
 <%= form.govuk_text_field :email, width: "full", label: { size: "s", text: "Email address" },
-                                  hint: { text: "Email must be a valid Department for Education address, like name@education.gov.uk" } %>
+                                  hint: { text: "Email address must be a valid Department for Education address, like name@education.gov.uk" } %>

--- a/app/views/users/check/show.html.erb
+++ b/app/views/users/check/show.html.erb
@@ -1,4 +1,4 @@
 <%= render CheckYourAnswers::View.new(
-      rows: rows, subtitle: "Add support user", caption: "Add support user", back_path: back_path,
+      rows: rows, subtitle: "Support user", caption: "Support user", back_path: back_path,
       save_button_text: "Save user", save_path: save_path, cancel_path: users_path, method: method
     ) %>

--- a/app/views/users/check/show.html.erb
+++ b/app/views/users/check/show.html.erb
@@ -1,4 +1,4 @@
 <%= render CheckYourAnswers::View.new(
-      rows: rows, subtitle: "Support user", caption: "Support user", back_path: back_path,
+      rows: rows, title: "Change support user", caption: "Support user - #{model.name}", back_path: back_path,
       save_button_text: "Save user", save_path: save_path, cancel_path: users_path, method: method
     ) %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,21 +1,20 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
         text: "Back",
-        href: users_path,
+        href: user_path(@user),
       ) %>
 <% end %>
 
 <%= form_for @user  do  |form| %>
-  <% page_data(title: "Add support user", subtitle: "personal details", header: false, error: @user.errors.present?) %>
+  <% page_data(title: "Change support user", subtitle: "personal details", header: false, error: @user.errors.present?) %>
 
   <%= content_for(:page_alerts) { form.govuk_error_summary } %>
-
-  <%= form.govuk_fieldset legend: { text: "Personal Details" }, caption: { text: "Add support user" } do %>
+  <%= form.govuk_fieldset legend: { text: "Personal Details" }, caption: { text: "Support user - #{@user.name}" } do %>
     <%= render partial: "fields", locals: { form: form } %>
     <%= form.govuk_submit %>
   <% end %>
 <% end %>
 
 <p class="govuk-body">
-  <%= govuk_link_to("Cancel", users_path) %>
+  <%= govuk_link_to("Cancel", user_path(@user)) %>
 </p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,7 +6,7 @@
       table.with_head do |head|
         head.with_row do |row|
           row.with_cell(text: "Name")
-          row.with_cell(text: "Email")
+          row.with_cell(text: "Email address")
         end
       end
       table.with_body do |body|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,3 +42,4 @@ en:
       check:
         user:
           add: "Support user added"
+          update: "Support user updated"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   resources :providers, only: %i[index]
 
-  resources :users, only: %i[index new create show edit] do
+  resources :users do
     checkable(:users)
     resource :delete, only: [:show, :destroy], module: :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   def checkable(model)
+    resource :check, only: %i[show update], path: "/check", controller: "#{model}/check"
+
     collection do
       scope module: model do
         resource :check, only: %i[new create], path: "/check", as: "#{model.to_s.singularize}_confirm",

--- a/spec/components/check_your_answers/view_preview.rb
+++ b/spec/components/check_your_answers/view_preview.rb
@@ -2,8 +2,15 @@ module CheckYourAnswers
   class ViewPreview < ViewComponent::Preview
     def new_user_check_your_answers
       render(CheckYourAnswers::View.new(
-               rows: rows, subtitle: "Add support user", caption: "Add support user", back_path: back_path,
-               save_button_text: "Save user", save_path: save_path, cancel_path: cancel_path
+               rows: new_user_rows, subtitle: "Add support user", caption: "Add support user", back_path: back_path,
+               save_button_text: "Save user", save_path: save_path, cancel_path: cancel_path, method: :post
+             ))
+    end
+
+    def existing_user_check_your_answers
+      render(CheckYourAnswers::View.new(
+               rows: existing_user_rows, subtitle: "Support user", caption: "Support user", back_path: back_path,
+               save_button_text: "Save user", save_path: save_path, cancel_path: cancel_path, method: :patch
              ))
     end
 
@@ -13,11 +20,23 @@ module CheckYourAnswers
       @new_user ||= ::FactoryBot.build(:user)
     end
 
-    def rows
+    def new_user_rows
       [
         { key: { text: "First name" }, value: { text: new_user.first_name }, actions: [{ href: new_user_path }] },
         { key: { text: "Last name" }, value: { text: new_user.last_name }, actions: [{ href: new_user_path }] },
         { key: { text: "Email address" }, value: { text: new_user.email }, actions: [{ href: new_user_path }] },
+      ]
+    end
+
+    def existing_user
+      @existing_user ||= ::FactoryBot.build_stubbed(:user)
+    end
+
+    def existing_user_rows
+      [
+        { key: { text: "First name" }, value: { text: existing_user.first_name }, actions: [{ href: edit_user_path(existing_user) }] },
+        { key: { text: "Last name" }, value: { text: existing_user.last_name }, actions: [{ href: edit_user_path(existing_user) }] },
+        { key: { text: "Email address" }, value: { text: existing_user.email }, actions: [{ href: edit_user_path(existing_user) }] },
       ]
     end
 

--- a/spec/components/check_your_answers/view_spec.rb
+++ b/spec/components/check_your_answers/view_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CheckYourAnswers::View, type: :component do
   let(:save_path) { "/save/path" }
   let(:cancel_path) { "/cancel/path" }
   let(:title) { "Check your answers" }
+  let(:method) { :post }
 
   subject(:component_instance) do
     described_class.new(
@@ -19,7 +20,8 @@ RSpec.describe CheckYourAnswers::View, type: :component do
       save_button_text: save_button_text,
       save_path: save_path,
       cancel_path: cancel_path,
-      title: title
+      title: title,
+      method: method
     )
   end
 
@@ -36,6 +38,20 @@ RSpec.describe CheckYourAnswers::View, type: :component do
 
     it "renders cancel link" do
       expect(rendered_component).to have_link("Cancel", href: cancel_path)
+    end
+
+    it "has correct form method" do
+      expect(rendered_component).to have_css('form[method="post"]')
+      expect(rendered_component).not_to have_css('input[name="_method"][value="patch"]', visible: false)
+    end
+
+    context "when method is patch" do
+      let(:method) { :patch }
+
+      it "has correct form method" do
+        expect(rendered_component).to have_css('form[method="post"]')
+        expect(rendered_component).to have_css('input[name="_method"][value="patch"]', visible: false)
+      end
     end
 
     context "when rows are empty" do

--- a/spec/features/end_to_end/users/creating_user_spec.rb
+++ b/spec/features/end_to_end/users/creating_user_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "User management" do
 
   def and_i_can_see_the_error_summary
     expect(page).to have_error_summary(
-      "Enter last name",
+      "Enter first name",
       "Enter last name",
       "Enter email address"
     )

--- a/spec/features/end_to_end/users/editing_user_spec.rb
+++ b/spec/features/end_to_end/users/editing_user_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+RSpec.feature "User management" do
+  scenario "deleting users" do
+    given_i_am_an_authenticated_user
+    and_i_have_a_user_to_edit
+    and_i_am_on_the_user_support_listing_page
+    and_i_can_see_the_page_title_support_users_with_the_count(count: 2)
+
+    and_i_click_on(current_user.name)
+    and_i_cannot_find("Change first name")
+
+    and_i_click_on("Back")
+    and_i_click_on(user_to_edit.name)
+    and_i_am_taken_to("/users/#{user_to_edit.id}")
+
+    and_i_can_see_the_page_title_for_view_support_user
+    and_i_click_on("Change first name")
+    and_i_am_taken_to("/users/#{user_to_edit.id}/edit")
+
+    and_i_can_see_the_page_title_for_personal_details
+    and_i_do_not_see_error_summary
+    and_i_fill_in_the_first_name_incorrectly
+
+    and_i_click_on("Continue")
+    and_i_can_see_the_error_summary
+    and_i_can_see_the_page_title_for_personal_details_with_error
+
+    and_i_fill_in_the_first_name
+
+    and_i_click_on("Continue")
+
+    and_i_am_taken_to("/users/#{user_to_edit.id}/check")
+
+    when_i_click_on("Save user")
+
+    then_i_see_the_success_message
+    and_i_am_taken_to("/users")
+
+    and_i_can_see_the_page_title_support_users_with_the_count(count: 2)
+    and_i_cannot_find(old_user_to_edit_name)
+    and_the_user_to_edit_is_edited
+    and_i_see_my_changes(user_to_edit.name)
+  end
+
+  def and_i_fill_in_the_first_name_incorrectly
+    page.fill_in "First name", with: ""
+  end
+
+  def and_i_fill_in_the_first_name
+    page.fill_in "First name", with: new_first_name
+  end
+
+  def and_the_user_to_edit_is_edited
+    expect(user_to_edit.reload.first_name).to eq(new_first_name)
+  end
+
+  def new_first_name
+    "Nouveau"
+  end
+
+  def old_first_name
+    "Vieux"
+  end
+
+  def and_i_see_my_changes(link)
+    expect(page).to have_link(link)
+  end
+
+  def and_i_cannot_find(button_or_link)
+    expect(page).not_to have_button(button_or_link)
+    expect(page).not_to have_link(button_or_link)
+  end
+
+  def and_i_can_see_the_page_title_support_users_with_the_count(count: 1)
+    expect(page).to have_title("Support users (#{count}) - Register of training providers - GOV.UK")
+  end
+
+  def and_i_am_on_the_user_support_listing_page
+    visit "/users"
+  end
+
+  def user_to_edit
+    @user_to_edit ||= create(:user, first_name: old_first_name)
+  end
+
+  def old_user_to_edit_name
+    @old_user_to_edit_name ||= user_to_edit.name
+  end
+
+  alias_method :and_i_have_a_user_to_edit, :user_to_edit
+
+  def then_i_see_the_success_message
+    expect(page).to have_notification_banner("Success", "Support user updated")
+  end
+
+  def and_i_can_see_the_page_title_for_check_your_answers
+    expect(page).to have_title("Check your answers - Add support user - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_view_support_user
+    expect(page).to have_title("View support user - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_personal_details
+    expect(page).to have_title("Change support user - personal details - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_personal_details_with_error
+    expect(page).to have_title("Error: Change support user - personal details - Register of training providers - GOV.UK")
+  end
+
+  def and_i_do_not_see_error_summary
+    expect(page).not_to have_error_summary
+  end
+
+  def and_i_can_see_the_error_summary
+    expect(page).to have_error_summary(
+      "Enter first name",
+    )
+  end
+end

--- a/spec/features/end_to_end/users/editing_user_spec.rb
+++ b/spec/features/end_to_end/users/editing_user_spec.rb
@@ -32,6 +32,8 @@ RSpec.feature "User management" do
 
     and_i_am_taken_to("/users/#{user_to_edit.id}/check")
 
+    and_i_can_see_the_page_title_for_check_your_answers
+    and_i_show_see_new_first_name
     when_i_click_on("Save user")
 
     then_i_see_the_success_message
@@ -41,6 +43,10 @@ RSpec.feature "User management" do
     and_i_cannot_find(old_user_to_edit_name)
     and_the_user_to_edit_is_edited
     and_i_see_my_changes(user_to_edit.name)
+  end
+
+  def and_i_show_see_new_first_name
+    expect(page).to have_css(".govuk-summary-list__value", text: new_first_name)
   end
 
   def and_i_fill_in_the_first_name_incorrectly
@@ -95,7 +101,9 @@ RSpec.feature "User management" do
   end
 
   def and_i_can_see_the_page_title_for_check_your_answers
-    expect(page).to have_title("Check your answers - Add support user - Register of training providers - GOV.UK")
+    expect(page).to have_title("Change support user - Register of training providers - GOV.UK")
+
+    expect(page).to have_heading("h1", "Support user - #{user_to_edit.name}Check your answers")
   end
 
   def and_i_can_see_the_page_title_for_view_support_user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -257,4 +257,31 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#name" do
+    let(:user) { create(:user, first_name: "John", last_name: "Doe") }
+
+    it "returns full name when unchanged" do
+      expect(user.name).to eq "John Doe"
+    end
+
+    it "returns original name when changed but not saved" do
+      user.first_name = "Jane"
+      expect(user.name).to eq "John Doe"
+
+      user.last_name = "Smith"
+      expect(user.name).to eq "John Doe"
+    end
+
+    it "returns new name after saving" do
+      user.update!(first_name: "Jane", last_name: "Smith")
+      expect(user.name).to eq "Jane Smith"
+    end
+
+    it "handles new records with changes" do
+      new_user = build(:user, first_name: "Alice", last_name: "Wonder")
+      new_user.first_name = "Alicia"
+      expect(new_user.name).to eq "Alicia Wonder"
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -108,11 +108,15 @@ RSpec.describe User, type: :model do
         include ActiveModel::Model
         include ActiveModel::Attributes
 
+        attribute :id, :integer
         attribute :foo, :string
         attribute :bar, :integer
 
         def ==(other)
           other.is_a?(DummyModel) && foo == other.foo && bar == other.bar
+        end
+
+        def self.find(id)
         end
       end)
     end
@@ -169,6 +173,51 @@ RSpec.describe User, type: :model do
 
         expect(result).to be_a(DummyModel)
         expect(result).to have_attributes(foo: nil, bar: nil)
+      end
+    end
+
+    context "when id is provided" do
+      let!(:temp_record) do
+        create(:temporary_record,
+               creator: user,
+               record_type: "DummyModel",
+               purpose: :check_your_answers,
+               data: { "foo" => "temp_value", "bar" => 456 },
+               expires_at: 1.hour.from_now)
+      end
+
+      before do
+        allow(DummyModel).to receive(:find).with(42).and_return(
+          DummyModel.new.tap do |model|
+            model.foo = "existing_value"
+            model.bar = 999
+            model.id = 42
+          end
+        )
+      end
+
+      it "finds the existing record and merges temporary data into it" do
+        result = user.load_temporary(DummyModel, purpose: :check_your_answers, id: 42)
+
+        expect(DummyModel).to have_received(:find).with(42)
+        expect(result).to be_a(DummyModel)
+        expect(result.foo).to eq("temp_value")
+        expect(result.bar).to eq(456)
+        expect(result.id).to eq(42)
+      end
+
+      context "when no temporary record exists for the purpose" do
+        let!(:temp_record) { nil }
+
+        it "returns the found record without any merging" do
+          result = user.load_temporary(DummyModel, purpose: :check_your_answers, id: 42)
+
+          expect(DummyModel).to have_received(:find).with(42)
+          expect(result).to be_a(DummyModel)
+          expect(result.foo).to eq("existing_value")
+          expect(result.bar).to eq(999)
+          expect(result.id).to eq(42)
+        end
       end
     end
   end

--- a/spec/support/features/matchers/heading_matcher.rb
+++ b/spec/support/features/matchers/heading_matcher.rb
@@ -16,13 +16,14 @@ RSpec::Matchers.define :have_heading do |tag, text|
   failure_message do |page_or_html|
     node = wrap_as_capybara_node(page_or_html)
 
-    count = node.all(tag).size
+    tags = node.all(tag)
+    count = tags.size
     if count == 0
       "expected page to have a #{tag} heading with text '#{text}', but none was found"
     elsif tag.downcase == "h1" && count > 1
       "expected exactly one #{tag}, but found #{count}"
     else
-      "found one #{tag}, but text didn't match '#{text}'"
+      "found one #{tag}, but text didn't match '#{text}' actual text is '#{tags.first.text}'"
     end
   end
 end

--- a/spec/support/features/matchers/notification_banner_matcher.rb
+++ b/spec/support/features/matchers/notification_banner_matcher.rb
@@ -1,10 +1,8 @@
 RSpec::Matchers.define :have_notification_banner do |expected_title, expected_content|
   match do |page|
-    banner = page.find(".govuk-notification-banner")
-    expect(banner).not_to be_nil
-
-    expect(banner).to have_css(".govuk-notification-banner__header", text: expected_title)
-    expect(banner).to have_css(".govuk-notification-banner__content", text: expected_content)
+    page.has_css?(".govuk-notification-banner") &&
+      page.has_css?(".govuk-notification-banner__header", text: expected_title) &&
+      page.has_css?(".govuk-notification-banner__content", text: expected_content)
   end
 
   failure_message do |_page|


### PR DESCRIPTION
### Context
The change support user details flow

### Changes proposed in this pull request
Added the change support user details flow

### Guidance to review

1. Create a new user
2. Navigate to the newly created user
3. Click on `Change` links
4. Change some thing
5. Check your answers
6. Save user

![image](https://github.com/user-attachments/assets/377b8852-dcf2-44b5-aa3b-4197b8992b29)
![image](https://github.com/user-attachments/assets/c948d7ca-967b-471d-92be-2d095003f04c)
![image](https://github.com/user-attachments/assets/ba5e36fa-9adb-4a47-aae8-d838b21e0162)
![image](https://github.com/user-attachments/assets/45f248b0-2610-400d-bb70-147ca4040029)



