### PR TITLE
[0082] Fix snag for change user details

### DIFF
--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -62,6 +62,10 @@ private
     model_class.name.underscore
   end
 
+  def change_path
+    back_path
+  end
+
   def new_model_path(query_params = {})
     send("new_#{model_name}_path", query_params)
   end

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -62,21 +62,16 @@ private
     model_class.name.underscore
   end
 
-  def new_model_path
-    @new_model_path ||= url_for([:new, model_name.to_sym])
+  def new_model_path(query_params = {})
+    send("new_#{model_name}_path", query_params)
   end
 
-  def edit_model_path
-    @edit_model_path ||= Rails.application.routes.url_helpers.url_for(
-      controller: model_name.pluralize,
-      action: "edit",
-      id: model,
-      only_path: true
-    )
+  def edit_model_path(query_params = {})
+    send("edit_#{model_name}_path", model, query_params)
   end
 
   def back_path
-    model_id.present? ? edit_model_path : new_model_path
+    model_id.present? ? edit_model_path(goto: "confirm") : new_model_path(goto: "confirm")
   end
 
   def success_path

--- a/app/controllers/users/check_controller.rb
+++ b/app/controllers/users/check_controller.rb
@@ -3,13 +3,13 @@ class Users::CheckController < CheckController
     [
       { key: { text: "First name" },
         value: { text: model.first_name },
-        actions: [{ href: new_model_path, visually_hidden_text: "first name" }] },
+        actions: [{ href: change_path, visually_hidden_text: "first name" }] },
       { key: { text: "Last name" },
         value: { text: model.last_name },
-        actions: [{ href: new_model_path, visually_hidden_text: "last name" }] },
+        actions: [{ href: change_path, visually_hidden_text: "last name" }] },
       { key: { text: "Email address" },
         value: { text: model.email },
-        actions: [{ href: new_model_path, visually_hidden_text: "email address" }] },
+        actions: [{ href: change_path, visually_hidden_text: "email address" }] },
     ]
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
         text: "Back",
-        href: user_path(@user),
+        href: params[:goto] == "confirm" ? user_check_path(@user) : user_path(@user),
       ) %>
 <% end %>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,7 +9,7 @@
   <% page_data(title: "Change support user", subtitle: "personal details", header: false, error: @user.errors.present?) %>
 
   <%= content_for(:page_alerts) { form.govuk_error_summary } %>
-  <%= form.govuk_fieldset legend: { text: "Personal Details" }, caption: { text: "Support user - #{@user.name}" } do %>
+  <%= form.govuk_fieldset legend: { text: "Personal details" }, caption: { text: "Support user - #{@user.name}" } do %>
     <%= render partial: "fields", locals: { form: form } %>
     <%= form.govuk_submit %>
   <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,7 +10,7 @@
 
   <%= content_for(:page_alerts) { form.govuk_error_summary } %>
 
-  <%= form.govuk_fieldset legend: { text: "Personal Details" }, caption: { text: "Add support user" } do %>
+  <%= form.govuk_fieldset legend: { text: "Personal details" }, caption: { text: "Add support user" } do %>
     <%= render partial: "fields", locals: { form: form } %>
     <%= form.govuk_submit %>
   <% end %>

--- a/spec/features/end_to_end/users/editing_user_spec.rb
+++ b/spec/features/end_to_end/users/editing_user_spec.rb
@@ -31,6 +31,10 @@ RSpec.feature "User management" do
     and_i_click_on("Continue")
 
     and_i_am_taken_to("/users/#{user_to_edit.id}/check")
+    and_i_click_on("Back")
+
+    and_i_am_taken_to("/users/#{user_to_edit.id}/edit?goto=confirm")
+    and_i_click_on("Continue")
 
     and_i_can_see_the_page_title_for_check_your_answers
     and_i_show_see_new_first_name

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "users/new.html.erb", type: :view do
-  let(:user) { User.new }
+RSpec.describe "users/edit.html.erb", type: :view do
+  let(:user) { create(:user) }
+  let(:goto) { nil }
 
   before do
     assign(:user, user)
     allow(view).to receive(:page_data)
+    controller.params.merge!(goto: goto).compact!
 
     render
   end
@@ -14,7 +16,7 @@ RSpec.describe "users/new.html.erb", type: :view do
     expect(view).to have_received(:page_data).with({ error: false,
                                                      header: false,
                                                      subtitle: "personal details",
-                                                     title: "Add support user" })
+                                                     title: "Change support user" })
   end
 
   it "renders the continue button" do
@@ -22,7 +24,7 @@ RSpec.describe "users/new.html.erb", type: :view do
   end
 
   it "renders heading" do
-    caption = "Add support user"
+    caption = "Support user - #{user.name}"
     heading = "Personal details"
     expect(rendered).to have_heading("h1", "#{caption}#{heading}")
   end
@@ -35,15 +37,27 @@ RSpec.describe "users/new.html.erb", type: :view do
   end
 
   it "renders the cancel link" do
-    expect(rendered).to have_link("Cancel", href: users_path)
+    expect(rendered).to have_link("Cancel", href: user_path(user))
   end
+
   it "renders the back link" do
-    expect(view.content_for(:breadcrumbs)).to have_back_link(users_path)
+    expect(view.content_for(:breadcrumbs)).to have_back_link(user_path(user))
+  end
+
+  context "when goto is confirm" do
+    let(:goto) { "confirm" }
+
+    it "renders the back link" do
+      expect(view.content_for(:breadcrumbs)).to have_back_link(user_check_path(user))
+    end
   end
 
   context "with validation errors" do
     let(:user) do
-      user = User.new
+      user = create(:user)
+      user.first_name = ""
+      user.last_name = ""
+      user.email = ""
       user.valid?
       user
     end
@@ -52,7 +66,7 @@ RSpec.describe "users/new.html.erb", type: :view do
       expect(view).to have_received(:page_data).with({ error: true,
                                                        header: false,
                                                        subtitle: "personal details",
-                                                       title: "Add support user" })
+                                                       title: "Change support user" })
     end
 
     it "renders the error summary" do


### PR DESCRIPTION
### Context
Snag for change user details

### Changes proposed in this pull request
Fixed change link, it was defaulted to new user instead of edit user
Fixed back link, it needed to know where go in a dead loop
Amended to `d` from `D`, casing matters

### Guidance to review

https://trello.com/c/oiJ0xdhO/#comment-6863c3502a207845c4651b9c
https://trello.com/c/oiJ0xdhO/#comment-6863c25968e64ced53a99dc5
https://trello.com/c/oiJ0xdhO/#comment-6863c3b93af29aca0286a1ef