### PR TITLE
[0135] Add provider partial flow `Provider type` page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -1,26 +1,61 @@
 class ProvidersController < ApplicationController
   def index
-    current_user.clear_temporary(Providers::IsTheProviderAccredited, purpose: :check_your_answers)
+    [Providers::IsTheProviderAccredited,
+     Providers::ProviderType,].each do |form|
+      current_user.clear_temporary(form, purpose: :check_your_answers)
+    end
   end
 
   def new
-    @form = Providers::IsTheProviderAccredited.new
+    @form = current_user.load_temporary(Providers::IsTheProviderAccredited,
+                                        purpose: :check_your_answers)
   end
 
   def create
-    @form = Providers::IsTheProviderAccredited.new(provider_params)
+    @form = Providers::IsTheProviderAccredited.new(create_provider_params)
 
     if @form.valid?
       @form.save_as_temporary!(created_by: current_user, purpose: :check_your_answers)
-      redirect_to providers_path, flash: { success: "Provider added" }
+      redirect_to new_type_providers_path
     else
       render :new
     end
   end
 
+  def new_type
+    is_the_provider_accredited_form = current_user.load_temporary(Providers::IsTheProviderAccredited,
+                                                                  purpose: :check_your_answers)
+
+    if is_the_provider_accredited_form.nil? || is_the_provider_accredited_form.invalid?
+
+      # NOTE: Something is really wrong if we reach here, redirect to the new provider form
+      redirect_to new_providers_path
+      return
+    end
+
+    @form = Providers::ProviderType.new(is_the_provider_accredited_form.attributes)
+
+    render :new_type
+  end
+
+  def create_type
+    @form = Providers::ProviderType.new(create_new_type_provider_params)
+
+    if @form.valid?
+      @form.save_as_temporary!(created_by: current_user, purpose: :check_your_answers)
+      redirect_to providers_path, flash: { success: "Provider added" }
+    else
+      render :new_type
+    end
+  end
+
 private
 
-  def provider_params
+  def create_provider_params
     params.expect(provider: [:accreditation_status])
+  end
+
+  def create_new_type_provider_params
+    params.expect(provider: [:provider_type, :accreditation_status])
   end
 end

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -12,7 +12,7 @@ class ProvidersController < ApplicationController
   end
 
   def create
-    @form = Providers::IsTheProviderAccredited.new(create_provider_params)
+    @form = Providers::IsTheProviderAccredited.new(accreditation_status_params)
 
     if @form.valid?
       @form.save_as_temporary!(created_by: current_user, purpose: :check_your_answers)
@@ -51,7 +51,7 @@ class ProvidersController < ApplicationController
 
 private
 
-  def create_provider_params
+  def accreditation_status_params
     params.expect(provider: [:accreditation_status])
   end
 

--- a/app/forms/providers/provider_type.rb
+++ b/app/forms/providers/provider_type.rb
@@ -1,0 +1,47 @@
+module Providers
+  class ProviderType
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include AccreditationStatusValidator
+    include SaveAsTemporary
+
+    attribute :provider_type, :string
+
+    attribute :accreditation_status, :string
+
+    validates :provider_type, presence: true, provider_type: true
+
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "Provider")
+    end
+
+    def self.i18n_scope
+      :activerecord
+    end
+
+    def provider_type_options_for_radios
+      provider_types.keys.map do |key|
+        SelectOption.new(
+          key: key,
+          value: I18n.t("forms.providers.provider_type.provider_type.#{key}"),
+        )
+      end
+    end
+
+    alias_method :serializable_hash, :attributes
+
+    def accredited?
+      accreditation_status == AccreditationStatusEnum::ACCREDITED
+    end
+
+  private
+
+    def provider_types
+      if accredited?
+        ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES
+      else
+        ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES
+      end
+    end
+  end
+end

--- a/app/models/concerns/enums/accreditation_status_enum.rb
+++ b/app/models/concerns/enums/accreditation_status_enum.rb
@@ -6,6 +6,8 @@ module AccreditationStatusEnum
     unaccredited: "unaccredited"
   }.freeze
 
+  ACCREDITED = ACCREDITATION_STATUSES[:accredited]
+  UNACCREDITED = ACCREDITATION_STATUSES[:unaccredited]
   included do
     enum :accreditation_status, ACCREDITATION_STATUSES
   end

--- a/app/models/concerns/enums/provider_type_enum.rb
+++ b/app/models/concerns/enums/provider_type_enum.rb
@@ -1,0 +1,12 @@
+module ProviderTypeEnum
+  extend ActiveSupport::Concern
+
+  PROVIDER_TYPES = %i[hei scitt school other].index_with(&:to_s).freeze
+
+  ACCREDITED_PROVIDER_TYPES = PROVIDER_TYPES.slice(:hei, :scitt, :other).freeze
+  UNACCREDITED_PROVIDER_TYPES = PROVIDER_TYPES.slice(:hei, :school, :other).freeze
+
+  included do
+    enum :provider_type, PROVIDER_TYPES
+  end
+end

--- a/app/models/concerns/validators/provider_type_validator.rb
+++ b/app/models/concerns/validators/provider_type_validator.rb
@@ -1,0 +1,13 @@
+class ProviderTypeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    allowed_types = if record.accredited?
+                      ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values
+                    else
+                      ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values
+                    end
+
+    unless allowed_types.include?(value)
+      record.errors.add(attribute, :inclusion, value:)
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -34,12 +34,12 @@ class Provider < ApplicationRecord
 
   audited
 
-  enum :provider_type, hei: "hei", scitt: "scitt", school: "school", other: "other"
+  include ProviderTypeEnum
   include AccreditationStatusEnum
 
   scope :order_by_operating_name, -> { order(:operating_name) }
 
-  validates :provider_type, presence: true
+  validates :provider_type, presence: true, provider_type: true
 
   include AccreditationStatusValidator
 

--- a/app/views/providers/new_type.html.erb
+++ b/app/views/providers/new_type.html.erb
@@ -1,0 +1,32 @@
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+        text: "Back",
+        href: new_provider_path,
+      ) %>
+<% end %>
+
+<%= form_for @form, url: new_type_providers_path, method: :post do |form| %>
+  <% page_data(title: "Provider type", subtitle: "Add provider", header: false, error: @form.errors.present?) %>
+
+  <%= content_for(:page_alerts) { form.govuk_error_summary } %>
+
+  <%= form.hidden_field :accreditation_status %>
+  <%= form.hidden_field :provider_type %>
+
+  <%= form.govuk_radio_buttons_fieldset(:provider_type, legend: { text: "Provider type" }, caption: { text: "Add provider" }) do %>
+    <% form.object.provider_type_options_for_radios.each_with_index do |item, index| %>
+      <%= form.govuk_radio_button :provider_type, item[:key],
+                                  label: { text: item[:value] },
+                                  link_errors: index.zero? %>
+      <% if index == 1 %>
+        <%= form.govuk_radio_divider %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= form.govuk_submit %>
+
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to("Cancel", providers_path) %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,3 +69,9 @@ en:
         accreditation_status:
           accredited: "Yes"
           unaccredited: "No"
+      provider_type:
+        provider_type:
+          hei: "Higher education institution (HEI)"
+          scitt: "School-centred initial teacher training (SCITT)"
+          school: "School"
+          other: "Other"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,12 @@ Rails.application.routes.draw do
 
   resource :account, only: [:show]
 
-  resources :providers
+  resources :providers do
+    collection do
+      get "new/type", to: "providers#new_type", as: :new_type
+      post "new/type", to: "providers#create_type"
+    end
+  end
 
   resources :users do
     checkable(:users)

--- a/spec/features/end_to_end/providers/creating_provider_spec.rb
+++ b/spec/features/end_to_end/providers/creating_provider_spec.rb
@@ -20,10 +20,12 @@ RSpec.feature "Add Provider" do
 
     def and_i_fill_out_the_provider_form_with_valid_details(accreditation_status:)
       info = get_provider_information_for_the_forms(accreditation_status:)
+
       and_i_answer_the_accreditation_question(select_if_the_provider_is_accredited: info[:select_if_the_provider_is_accredited])
 
+      and_i_select_the_provider_type(select_provider_type: info[:select_provider_type])
+
       # NOTE: this should be in place once the user journey is implemented
-      # and_i_select_the_provider_type(select_provider_type: info[:select_provider_type])
       # and_i_fill_in_the_provider_details(provider_details: info[:provider_details])
     end
 
@@ -35,9 +37,34 @@ RSpec.feature "Add Provider" do
         unaccredited: "No",
       }[@provider_details_to_use.accreditation_status.to_sym]
 
+      select_provider_type = {
+        hei: "Higher education institution (HEI)",
+        scitt: "School-centred initial teacher training (SCITT)",
+        school: "School",
+        other: "Other",
+      }[@provider_details_to_use.provider_type.to_sym]
+
       {
         select_if_the_provider_is_accredited:,
+        select_provider_type:,
       }
+    end
+
+    def and_i_select_the_provider_type(select_provider_type:)
+      expect(TemporaryRecord.count).to eq(1)
+
+      and_i_am_taken_to("/providers/new/type")
+      and_i_can_see_the_title("Provider type - Add provider - Register of training providers - GOV.UK")
+      and_i_do_not_see_error_summary
+
+      and_i_click_on("Continue")
+
+      and_i_can_see_the_error_summary("Select provider type")
+      and_i_can_see_the_title("Error: Provider type - Add provider - Register of training providers - GOV.UK")
+
+      and_i_choose(select_provider_type)
+
+      and_i_click_on("Continue")
     end
 
     def and_i_answer_the_accreditation_question(select_if_the_provider_is_accredited:)

--- a/spec/forms/providers/provider_type_spec.rb
+++ b/spec/forms/providers/provider_type_spec.rb
@@ -1,0 +1,152 @@
+# spec/models/providers/is_the_provider_accredited_spec.rb
+require "rails_helper"
+
+RSpec.describe Providers::ProviderType, type: :model do
+  describe "model attributes and behaviour" do
+    let(:accreditation_status) { nil }
+    let(:provider_type) { nil }
+    subject { described_class.new(accreditation_status:, provider_type:) }
+
+    context "with valid accreditation_status" do
+      AccreditationStatusEnum::ACCREDITATION_STATUSES.each_value do |valid_status|
+        context "when accreditation_status is #{valid_status}" do
+          let(:accreditation_status) { valid_status }
+          let(:provider_type) { :hei }
+
+          it "is valid" do
+            expect(subject).to be_valid
+          end
+        end
+      end
+    end
+
+    context "with invalid accreditation_status" do
+      let(:accreditation_status) { "invalid_status" }
+      let(:provider_type) { ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values.first }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:accreditation_status]).to include("is not included in the list")
+      end
+    end
+
+    context "with nil accreditation_status" do
+      let(:accreditation_status) { nil }
+      let(:provider_type) { :hei }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:accreditation_status]).to include("Select if the provider is accredited")
+      end
+    end
+
+    context "with valid accredited provider_type" do
+      ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.each_value do |valid_type|
+        context "when provider_type is #{valid_type}" do
+          let(:provider_type) { valid_type }
+          let(:accreditation_status) { AccreditationStatusEnum::ACCREDITED }
+
+          it "is valid" do
+            expect(subject).to be_valid
+          end
+        end
+      end
+    end
+
+    context "with valid unaccredited provider_type" do
+      ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.each_value do |valid_type|
+        context "when provider_type is #{valid_type}" do
+          let(:provider_type) { valid_type }
+          let(:accreditation_status) { AccreditationStatusEnum::UNACCREDITED }
+
+          it "is valid" do
+            expect(subject).to be_valid
+          end
+        end
+      end
+    end
+
+    context "with invalid accredited provider_type" do
+      ["invalid_type", "scitt"].each do |invalid_type|
+        let(:provider_type) { invalid_type }
+        let(:accreditation_status) { AccreditationStatusEnum::UNACCREDITED }
+
+        it "is not valid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:provider_type]).to include("is not included in the list")
+        end
+      end
+
+      context "with invalid unaccredited provider_type" do
+        ["invalid_type", "school"].each do |invalid_type|
+          let(:provider_type) { invalid_type }
+          let(:accreditation_status) { AccreditationStatusEnum::ACCREDITED }
+
+          it "is not valid" do
+            expect(subject).not_to be_valid
+            expect(subject.errors[:provider_type]).to include("is not included in the list")
+          end
+        end
+
+        context "with nil provider_type" do
+          let(:provider_type) { nil }
+          let(:accreditation_status) { AccreditationStatusEnum::ACCREDITATION_STATUSES.values.first }
+
+          it "is not valid" do
+            expect(subject).not_to be_valid
+            expect(subject.errors[:provider_type]).to include("Select provider type")
+          end
+        end
+      end
+    end
+  end
+
+  describe ".model_name" do
+    it "returns Provider as model name for form builder" do
+      expect(described_class.model_name.name).to eq("Provider")
+    end
+  end
+
+  describe ".i18n_scope" do
+    it "returns :activerecord" do
+      expect(described_class.i18n_scope).to eq(:activerecord)
+    end
+  end
+
+  describe "#provider_type_options_for_radios" do
+    subject { described_class.new(accreditation_status:) }
+    context "when accredited" do
+      let(:accreditation_status) { AccreditationStatusEnum::ACCREDITED }
+      it "returns SelectOption objects with correct keys and values" do
+        options = subject.provider_type_options_for_radios
+
+        expect(options.size).to eq(ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.keys.size)
+
+        options.each do |option|
+          expect(option).to be_a(SelectOption)
+          expect(option.key).to be_a(Symbol)
+          expect(option.value).to eq(
+            I18n.t("forms.providers.provider_type.provider_type.#{option.key}")
+          )
+        end
+      end
+    end
+
+    context "when unaccredited" do
+      let(:accreditation_status) { AccreditationStatusEnum::UNACCREDITED }
+      it "returns SelectOption objects with correct keys and values" do
+        options = subject.provider_type_options_for_radios
+
+        expect(options.size).to eq(ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.keys.size)
+
+        options.each do |option|
+          expect(option).to be_a(SelectOption)
+          expect(option.key).to be_a(Symbol)
+          expect(option.value).to eq(
+            I18n.t("forms.providers.provider_type.provider_type.#{option.key}")
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/concerns/enums/accreditation_status_enum_spec.rb
+++ b/spec/models/concerns/enums/accreditation_status_enum_spec.rb
@@ -24,16 +24,4 @@ RSpec.describe AccreditationStatusEnum, type: :model do
       )
     end
   end
-
-  describe "enum behaviour" do
-    it "responds to accredited? and unaccredited?" do
-      model = AccreditationStatusEnumDummyModel.new(accreditation_status: :accredited)
-      expect(model.accredited?).to be true
-      expect(model.unaccredited?).to be false
-
-      model.accreditation_status = :unaccredited
-      expect(model.unaccredited?).to be true
-      expect(model.accredited?).to be false
-    end
-  end
 end

--- a/spec/models/concerns/enums/accreditation_status_enum_spec.rb
+++ b/spec/models/concerns/enums/accreditation_status_enum_spec.rb
@@ -2,23 +2,23 @@ require "rails_helper"
 
 RSpec.describe AccreditationStatusEnum, type: :model do
   before do
-    unless ActiveRecord::Base.connection.table_exists?(:dummy_models)
+    unless ActiveRecord::Base.connection.table_exists?(:accreditation_status_enum_dummy_models)
       ActiveRecord::Schema.define do
-        create_table :dummy_models, force: true do |t|
+        create_table :accreditation_status_enum_dummy_models, force: true do |t|
           t.string :accreditation_status
         end
       end
     end
 
-    stub_const("DummyModel", Class.new(ApplicationRecord) do
-      self.table_name = "dummy_models"
+    stub_const("AccreditationStatusEnumDummyModel", Class.new(ApplicationRecord) do
+      self.table_name = "accreditation_status_enum_dummy_models"
       include AccreditationStatusEnum
     end)
   end
 
   describe "enum definition" do
     it "defines accreditation_status enum with correct values" do
-      expect(DummyModel.accreditation_statuses).to eq(
+      expect(AccreditationStatusEnumDummyModel.accreditation_statuses).to eq(
         "accredited" => "accredited",
         "unaccredited" => "unaccredited"
       )
@@ -27,7 +27,7 @@ RSpec.describe AccreditationStatusEnum, type: :model do
 
   describe "enum behaviour" do
     it "responds to accredited? and unaccredited?" do
-      model = DummyModel.new(accreditation_status: :accredited)
+      model = AccreditationStatusEnumDummyModel.new(accreditation_status: :accredited)
       expect(model.accredited?).to be true
       expect(model.unaccredited?).to be false
 

--- a/spec/models/concerns/enums/provider_type_enum_spec.rb
+++ b/spec/models/concerns/enums/provider_type_enum_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe ProviderTypeEnum, type: :model do
+  before do
+    unless ActiveRecord::Base.connection.table_exists?(:provider_type_enum_dummy_models)
+      ActiveRecord::Schema.define do
+        create_table :provider_type_enum_dummy_models, force: true do |t|
+          t.string :provider_type
+        end
+      end
+    end
+
+    stub_const("ProviderTypeEnumDummyModel", Class.new(ApplicationRecord) do
+      self.table_name = "provider_type_enum_dummy_models"
+      include ProviderTypeEnum
+    end)
+  end
+
+  describe "enum definition" do
+    it "defines provider_type enum with correct values" do
+      expect(ProviderTypeEnumDummyModel.provider_types).to eq(
+        {
+          "hei" => "hei",
+          "scitt" => "scitt",
+          "school" => "school",
+          "other" => "other"
+        }
+      )
+    end
+  end
+
+  describe "enum behaviour" do
+    it "responds to hei?, scitt?, school?, other?" do
+      model = ProviderTypeEnumDummyModel.new(provider_type: :hei)
+      expect(model.hei?).to be true
+      expect(model.scitt?).to be false
+      expect(model.school?).to be false
+      expect(model.other?).to be false
+
+      model.provider_type = :scitt
+      expect(model.scitt?).to be true
+      expect(model.hei?).to be false
+    end
+  end
+end

--- a/spec/models/concerns/enums/provider_type_enum_spec.rb
+++ b/spec/models/concerns/enums/provider_type_enum_spec.rb
@@ -28,18 +28,4 @@ RSpec.describe ProviderTypeEnum, type: :model do
       )
     end
   end
-
-  describe "enum behaviour" do
-    it "responds to hei?, scitt?, school?, other?" do
-      model = ProviderTypeEnumDummyModel.new(provider_type: :hei)
-      expect(model.hei?).to be true
-      expect(model.scitt?).to be false
-      expect(model.school?).to be false
-      expect(model.other?).to be false
-
-      model.provider_type = :scitt
-      expect(model.scitt?).to be true
-      expect(model.hei?).to be false
-    end
-  end
 end

--- a/spec/models/concerns/validators/provider_type_validator._spec.rb
+++ b/spec/models/concerns/validators/provider_type_validator._spec.rb
@@ -32,11 +32,12 @@ RSpec.describe ProviderTypeValidator, type: :model do
     end
 
     context "with invalid provider types" do
-      let(:provider_type) { (ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values).first }
-
-      it "is invalid when provider_type is #{(ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values).first}" do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:provider_type]).to include("is not included in the list")
+      (ProviderTypeEnum::PROVIDER_TYPES.values - ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values).each do |invalid_type|
+        let(:provider_type) { invalid_type }
+        it "is invalid when provider_type is #{invalid_type}" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:provider_type]).to include("is not included in the list")
+        end
       end
     end
   end
@@ -53,11 +54,12 @@ RSpec.describe ProviderTypeValidator, type: :model do
       end
     end
     context "with invalid provider types" do
-      let(:provider_type) { (ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values).first }
-
-      it "is invalid when provider_type is #{(ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values).first}" do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:provider_type]).to include("is not included in the list")
+      (ProviderTypeEnum::PROVIDER_TYPES.values - ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values).each do |invalid_type|
+        let(:provider_type) { invalid_type }
+        it "is invalid when provider_type is #{invalid_type}" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:provider_type]).to include("is not included in the list")
+        end
       end
     end
   end

--- a/spec/models/concerns/validators/provider_type_validator._spec.rb
+++ b/spec/models/concerns/validators/provider_type_validator._spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe ProviderTypeValidator, type: :model do
+  before do
+    stub_const("DummyModel", Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :provider_type, :accredited_status_override
+
+      validates :provider_type, provider_type: true
+
+      def accredited?
+        accredited_status_override
+      end
+    end)
+  end
+
+  subject { DummyModel.new(provider_type:, accredited_status_override:) }
+
+  context "when accredited" do
+    let(:accredited_status_override) { true }
+
+    context "with valid provider types" do
+      ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.each_value do |valid_type|
+        let(:provider_type) { valid_type }
+
+        it "is valid when provider_type is #{valid_type}" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    context "with invalid provider types" do
+      let(:provider_type) { (ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values).first }
+
+      it "is invalid when provider_type is #{(ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values).first}" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:provider_type]).to include("is not included in the list")
+      end
+    end
+  end
+
+  context "when unaccredited" do
+    let(:accredited_status_override) { false }
+    context "with valid provider types" do
+      ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.each_value do |valid_type|
+        let(:provider_type) { valid_type }
+
+        it "is valid when provider_type is #{valid_type}" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+    context "with invalid provider types" do
+      let(:provider_type) { (ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values).first }
+
+      it "is invalid when provider_type is #{(ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.values - ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.values).first}" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:provider_type]).to include("is not included in the list")
+      end
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -17,10 +17,24 @@ RSpec.describe Provider, type: :model do
   end
 
   describe "enums" do
-    it do
-      is_expected.to define_enum_for(:provider_type)
-        .with_values(hei: "hei", scitt: "scitt", school: "school", other: "other")
-        .backed_by_column_of_type(:string)
+    context "provider is accredited" do
+      let(:provider) { create(:provider, :accredited) }
+
+      it do
+        expect(subject).to define_enum_for(:provider_type)
+          .with_values(hei: "hei", scitt: "scitt", school: "school", other: "other")
+          .backed_by_column_of_type(:string)
+      end
+    end
+
+    context "provider is unaccredited" do
+      let(:provider) { create(:provider, :unaccredited) }
+
+      it do
+        expect(subject).to define_enum_for(:provider_type)
+          .with_values(hei: "hei", scitt: "scitt", school: "school", other: "other")
+          .backed_by_column_of_type(:string)
+      end
     end
     it do
       is_expected.to define_enum_for(:accreditation_status)

--- a/spec/views/provider/new_type.html.erb_spec.rb
+++ b/spec/views/provider/new_type.html.erb_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "providers/new_type.html.erb", type: :view do
+  let(:form) { Providers::ProviderType.new(accreditation_status: :accredited) }
+
+  before do
+    assign(:form, form)
+    allow(view).to receive(:page_data)
+
+    render
+  end
+
+  it "calls page_data" do
+    expect(view).to have_received(:page_data).with({ error: false,
+                                                     header: false,
+                                                     title: "Provider type",
+                                                     subtitle: "Add provider" })
+  end
+
+  it "renders the continue button" do
+    expect(rendered).to have_button("Continue")
+  end
+
+  it "renders heading" do
+    caption = "Add provider"
+    heading = "Provider type"
+    expect(rendered).to have_heading("h1", "#{caption}#{heading}")
+  end
+
+  it "renders the form" do
+    expect(rendered).to have_selector("form")
+    expect(rendered).to have_selector("input[name='provider[provider_type]']", count: 3)
+  end
+
+  it "renders option for scitt" do
+    expect(rendered).to have_selector("input[value=\"scitt\"]", count: 1)
+  end
+
+  context "with provider as unaccredited" do
+    let(:form) { Providers::ProviderType.new(accreditation_status: :unaccredited) }
+
+    it "renders the form" do
+      expect(rendered).to have_selector("form")
+      expect(rendered).to have_selector("input[name='provider[provider_type]']", count: 3)
+    end
+
+    it "renders option for school" do
+      expect(rendered).to have_selector("input[value=\"school\"]", count: 1)
+    end
+  end
+
+  it "renders the cancel link" do
+    expect(rendered).to have_link("Cancel", href: providers_path)
+  end
+  it "renders the back link" do
+    expect(view.content_for(:breadcrumbs)).to have_back_link(new_provider_path)
+  end
+
+  context "with validation errors" do
+    let(:form) do
+      provider = Providers::ProviderType.new(accreditation_status: :accredited)
+      provider.valid?
+      provider
+    end
+
+    it "calls page_data with error" do
+      expect(view).to have_received(:page_data).with({ error: true,
+                                                       header: false,
+                                                       title: "Provider type",
+                                                       subtitle: "Add provider" })
+    end
+
+    it "renders the error summary" do
+      expect(view.content_for(:page_alerts)).to have_error_summary(
+        "Select provider type"
+      )
+    end
+  end
+end

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -1,14 +1,6 @@
 FactoryBot.define do
   factory :provider do
-    provider_type { %i[school scitt hei other].sample }
-
-    accreditation_status do
-      if %i[school].include?(provider_type)
-        :unaccredited
-      else
-        %i[accredited unaccredited].sample
-      end
-    end
+    accredited
 
     legal_name do
       case provider_type.to_s
@@ -38,6 +30,16 @@ FactoryBot.define do
 
     trait :discarded do
       discarded_at { Time.zone.now }
+    end
+
+    trait :unaccredited do
+      accreditation_status { :unaccredited }
+      provider_type { ProviderTypeEnum::UNACCREDITED_PROVIDER_TYPES.keys.sample }
+    end
+
+    trait :accredited do
+      accreditation_status { :accredited }
+      provider_type { ProviderTypeEnum::ACCREDITED_PROVIDER_TYPES.keys.sample }
     end
   end
 end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review
There is a total of 3 pages before the `Check your answers`? page
This is the second page `Provider type`
The others are `Is the accredited provider?` and `Provider details`

The back links on `Provider type` page navigates and repopulates the value on `Is the accredited provider?` page

`spec/features/end_to_end/providers/creating_provider_spec.rb` has denoted a few places that stills needs to be implemented

This is the full journey
```mermaid
flowchart TD
    classDef page fill:#E0F7FA,stroke:#00ACC1,stroke-width:2px,color:#01579B,font-weight:bold;
    classDef button fill:#FFF8E1,stroke:#F57C00,stroke-width:2px,color:#E65100,font-style:italic;
    classDef action fill:#E8F5E9,stroke:#2E7D32,stroke-width:2px,color:#1B5E20,font-weight:bold;

    %% Subgraph styling
    style Step1 fill:#FFF3E0,stroke:#FB8C00,stroke-width:3px,color:#E65100
    style Step2 fill:#E8F5E9,stroke:#43A047,stroke-width:3px,color:#2E7D32
    style Step3 fill:#E3F2FD,stroke:#1976D2,stroke-width:3px,color:#0D47A1

    A1([📋 Providers Listing Page]):::page
    A2([➕ Add Provider Button]):::button

    subgraph Step1 [Accredited Provider Step]
        B1([✅ Is Accredited Provider? Page]):::page
        B2([➡️ Continue Button]):::button
    end

    subgraph Step2 [Provider Type Step]
        B3([🏷️ Provider Type Page]):::page
        B4([➡️ Continue Button]):::button
    end

    subgraph Step3 [Provider Details Step]
        B5([📝 Provider Details Page]):::page
        B6([➡️ Continue Button]):::button
    end

    C1([🔍 Check Your Answers Page]):::page
    C2([💾 Save Button]):::button
    C3((🎉 Provider is Saved)):::action
    subgraph Step4 [End Step]
        C4([📋 Redirects to Providers Listing Page]):::page
        C5[⚡ Success message]
   end
    %% Main flow
    A1 --> A2
    A2 --> B1
    B2 --> B3
    B4 --> B5
    B6 --> C1
    C1 --> C2
    C2 --> C3
    C3 --> C4
```

This PR focus on this bit
```mermaid
flowchart TD
 classDef page fill:#E0F7FA,stroke:#00ACC1,stroke-width:2px,color:#01579B,font-weight:bold;
    classDef button fill:#FFF8E1,stroke:#F57C00,stroke-width:2px,color:#E65100,font-style:italic;
    classDef action fill:#E8F5E9,stroke:#2E7D32,stroke-width:2px,color:#1B5E20,font-weight:bold;

    %% Subgraph styling
    style Step0 fill:#AFF3E0,stroke:#AB8C00,stroke-width:3px,color:#A65100
    style Step1 fill:#FFF3E0,stroke:#FB8C00,stroke-width:3px,color:#E65100
    style Step2 fill:#E8F5E9,stroke:#43A047,stroke-width:3px,color:#2E7D32

 subgraph Step1 [Accredited Provider Step]
        B1([✅ Is Accredited Provider? Page]):::page
        B2([➡️ Continue Button]):::button
    end


subgraph Step0 [PR Focus on this bit]
    subgraph Step2 [Provider Type Step]
        B3([🏷️ Provider Type Page]):::page
        B4([➡️ Continue Button]):::button
    end
    end

    subgraph Step3 [Stub]
        C4([📋 Redirects to Providers Listing Page]):::page
        C5[⚡ Success message]
    end

    %% Main flow
    B2 --> B3
    B4 --> C4
```

This works off https://github.com/DFE-Digital/register-training-providers/pull/136 &  https://github.com/DFE-Digital/register-training-providers/pull/137

Journey starts from https://register-training-providers-pr-140.test.teacherservices.cloud/provider/new and ends on `providers listing page`

#### Provider type page (Accredited)
<img width="1920" height="1934" alt="image" src="https://github.com/user-attachments/assets/27e0b317-469a-4738-9486-72dba8b44c9a" />

##### Validated

<img width="1920" height="2352" alt="image" src="https://github.com/user-attachments/assets/f13d9603-630d-40b2-98d3-9ce3c91878d3" />

#### Provider type page (Unaccredited)
<img width="1920" height="1922" alt="image" src="https://github.com/user-attachments/assets/f8d9485a-a9f3-4224-a315-4dd15693b16f" />


##### Validated
<img width="1920" height="2364" alt="image" src="https://github.com/user-attachments/assets/098d07ae-28e4-4737-9180-3f2c350a17c7" />
