### PR TITLE
[0132] View provider list with csv import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,8 @@ group :development, :review, :test do
 
   # A library for generating fake data such as names, addresses, and phone numbers.
   gem "faker"
+
+  gem "csv"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.2)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -580,6 +581,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   cssbundling-rails
+  csv
   debug
   discard (~> 1.4)
   dotenv-rails

--- a/lib/data/seed-providers.csv
+++ b/lib/data/seed-providers.csv
@@ -1,0 +1,852 @@
+[items]{#id}id,operating_name,legal_name,provider_type,code,ukprn,urn
+91b73ade-1703-4475-aef7-9f6a84fb947c,2Schools Consortium,Oakthorpe Primary School,school,T92,10045988,
+f492b075-3102-48c1-b9a4-9703fc8a3db3,2Schools Consortium,Oakthorpe Primary School,school,151,10045988,131407
+8c748117-6c7b-4807-a6e1-7593b4c42c84,AA Teamworks West Yorkshire SCITT,Great Heights Trust,school,2AT,10032342,
+33921de9-4a08-48ab-98d7-2797306add92,Abacus Belsize Primary School,,school,4A2,10042333,139837
+a48a610b-9edd-48fe-8895-35c140797ce5,Academy Transformation Trust,,school,7D7,10042700,139937
+11d62489-6d70-404c-9eb6-937e23b34e95,Achieve with TELA,,school,1R3,10038162,138527
+b5b4bebe-00e2-4ccd-8f62-779a85c8cd6b,Acklam Grange School,,school,2FD,10067565,145774
+c1d6f402-bcaa-4113-8ef9-07fb1379d0f3,Active Teacher Training,,school,2KL,10059514,138177
+12f0604a-5175-4cfd-9d47-d793d09bb2ff,Ad Astra SCITT,,school,3A8,10060899,
+188ba15d-1eed-4cb9-a27f-6502339b0f8e,Advance Learning Partnership,,school,2AL,10059549,137903
+c50a21ae-edc9-4505-bb27-14d22ca575de,Advance Teacher Training,,school,D5D,10059545,138084
+9cdc2ee9-10bd-4230-95d5-2ff878615a5b,Agnus Dei Catholic Schools,,school,2BD,10006280,102787
+02b7f013-aaa3-4950-b426-0c7fcfe10257,AIM Alliance Schools,,school,2FR,10016231,134798
+c29146f1-2fe3-4bca-a5b5-da12501826fc,Aireborough Partnership,,school,2JF,10073040,107809
+80932b13-3024-411a-8327-13029546b594,Aldridge Education,,school,7A1,10058195,
+6b543e0b-70ee-4f62-8883-d15fcf7176a7,Aletheia Academies Trust,,school,2T4,10059352,137609
+ae37a4e5-7170-4c13-8c09-969276b08cc5,All Saints Catholic Academy Trust,,school,5H5,10059575,
+ba4ec362-d99e-4fcd-a1fd-19f6ba985cd5,All Saints RC School,,school,2KH,10000225,149517
+53defbd8-2fe1-4b3f-8c37-aeb77e5f6a0d,Alliance of Bristol Catholic Schools (ABCs),,school,7A3,10035687,137627
+55f63e9f-7881-4905-91e3-a195bcbda6d7,Alliance of Leading Learning,,school,1HQ,10007848,136979
+5f8fb1be-55dd-4c76-acf4-586d83055b25,Alpha Academies Trust,,school,5A4,10058303,136681
+865982a6-de8e-4d10-9645-31ee41c7d11c,Ambition Teacher Training,Ambition Teacher Training,other,2A2,10095073,
+f42ea3cc-1821-4796-a34b-cf0f663ef266,An Daras Trust,,school,5D2,10059966,140514
+48ce2463-16c4-4b6b-a619-825763936de8,Anthem SCITT,,school,6A3,10058447,134003
+436133a0-7695-4e70-817c-d40a355d6cf9,Aquila,,school,2CA,10054668,142429
+8bba8ae8-d30d-4758-81cb-a5d3861e3676,Arbib Education Trust,,school,7A2,10058188,135631
+c2f31e47-9a45-4654-a5c8-6f4b7e3c7406,Archbishop Blanch School,,school,2KA,10003957,104705
+e99adbad-6528-472d-a212-3c887a68524d,Arden Alliance,,school,2BU,10031562,136333
+7e8663cb-6cd6-4f65-a199-6ffb7c94cb06,ARK Teacher Training,Ark Schools,school,1CS,10044534,135600
+7b2b4e07-ef9a-42d3-b63f-76385ab08f5f,Arthur Terry School,,school,1QN,10034759,138136
+3654ac7f-a228-4b70-8211-b4a8a87efff2,Arthur Terry SCITT,The Arthur Terry Learning Partnership,school,A67,10034759,
+83b8eab7-515b-4a5c-9f6c-2cf9451c6c32,Ascend Learning Trust,,school,4A5,10058663,144773
+8dd66e58-5936-4a8b-b38a-672377c8e8c3,Ashdene Primary School,,school,3A6,10074366,111227
+3a2587e2-7c81-49e9-baef-81b30dcdb670,Ashfield School ITT,,school,2L9,10036962,137981
+7f99555d-c4fd-4504-9b62-489bc03f1cc6,Ashmole Academy (North London Teaching Alliance),,school,1P2,10031563,136308
+546de5a9-3ead-41a0-8bbe-15403c2d8b75,Ashton on Mersey School SCITT,The Dean Trust,school,24L,10055366,
+5a3f92ed-1b7f-4344-b5e0-bb6754abedfb,Ashton Teacher Training Partnership,,school,29O,10082366,146816
+a1a22139-2c99-43d0-a389-5f08dc247e78,Aspirations Academies Trust,,school,2O1,10088769,
+2b516746-82ce-446c-abe0-820809d35234,Aspire Academy Trust,,school,2HB,10058372,136597
+2d5f2b40-d711-4485-a1a2-d7820155215a,Aspire Basingstoke,,school,28R,10054050,70241
+44154bad-1101-45aa-9d7c-7ed822e069b4,Aspire Education Alliance,,school,27K,10075063,101219
+c4aa1a4a-c6d6-448d-b76f-aa718557e77a,Aspire Teacher Training,,school,1XQ,10005790,140444
+09f648d2-4a75-48b9-9ba4-0a215debfc11,ASSET Education,,school,146,10048992,141819
+ab11842d-8963-4c29-abe3-2cb20d05aea0,Associated Merseyside Partnership SCITT,Lydiate Learning Trust,school,25F,10055360,
+ab4d2e97-2eb6-4300-ba09-c3d99e4f93fa,Aston Community Education Trust,,school,17U,10005790,143141
+6fc90eb7-23fb-49c7-889c-33a834212c12,Astra Aylesbury Hub,,school,2KM,10032610,136884
+fa5ebaf3-dcf9-4dc1-b654-e08be6ec579d,Astra Aylesbury Primary Hub,,school,5G5,10032610,110356
+8cee17f5-3ed3-4fda-9388-359f122d0b7d,Astra SCITT,Dr Challoner’s Grammar School,school,28E,10032610,
+305f6bb3-55a0-46c2-9d6e-a3eb65a076db,Astrea Academy Trust,,school,3A9,10067898,
+44455e36-95e2-40a6-afa3-605788229e49,ATT Partnership,,school,2CZ,10042286,139867
+5cabadeb-9418-42e9-9749-73bb9e93e530,Authentic Education Training school,,school,135,10003614,137998
+8b99ffa7-34dd-4c1c-ac8c-ea7c61ef4938,Avanti Schools Trust,,school,4A3,10058487,138227
+c059f562-42f8-4afe-8153-556e132fd84d,Avenue Primary Academy,,school,1J3,10053779,142177
+da4efeef-268b-4d96-9094-0c6915d4103f,Axbridge C of E First School Academy,,school,3J9,10058347,138763
+b88b55d5-05c6-4fde-a0da-e25b7681dfef,Balcarras Teaching School Hub,,school,14B,10032991,136474
+f7201554-12cf-421b-bf85-c2e00aa9ff36,Bannockburn Primary School,,school,200,10078056,100113
+e26d59fa-b1ee-49a0-a101-77722fc4b8d2,Barking Abbey SCITT,,school,5B1,10000527,
+45502d62-db37-4677-869b-e5a2769093ff,Barr Beacon School,,school,1BB,10034154,136885
+425b9827-304a-4356-bbeb-cbfa2f2744ab,Barr Beacon SCITT,Matrix Academy Trust,school,2AX,10053216,
+a2db9047-dfc4-42b5-a020-9eaf1a8fcfd9,Basingstoke Alliance SCITT,,school,1KH,10034865,10688
+206fd2fe-5052-4466-9cf2-56c0e3ee2bcc,Bath Spa University,Bath Spa University,hei,B20,10000571,133790
+6888a1a8-1eb1-42f6-9d5d-c464880ad633,BBL Teacher Training,,school,4A7,10067010,119301
+e3863b6e-8574-4ce5-aeb3-b68dc5a85bae,BCCET Teacher Training Partnership,,school,2B8,10061060,138054
+f52ed8fc-e00d-49ac-a4ec-dd92472ae229,Beal High School (NELTA),,school,1NA,10046736,140575
+278633fe-90a0-49c1-86aa-7f105aab9a74,Beaulieu Park Primary School,,school,3B2,10092263,145916
+d1e0c492-429e-4d08-8019-433ffc43369a,BEC Teacher Training,,school,B28,10058882,
+7bdc9e5b-c9ab-4a44-89b4-c084edefeef4,Beckfoot Trust Teacher Training,,school,1MU,10059960,139975
+372e7279-c581-48d1-bab9-df6b6b8280b0,Bedgrove Infant School,,school,1YP,10078291,110282
+b856626d-4af3-4ac6-90a3-c6b11700fcb1,Beech Hill,,school,14G,10063983,144524
+35325558-b148-49d8-ab81-251a088fa25e,Bellevue Place SCITT,,school,3V4,10059611,139775
+79136886-6a28-4de1-aa0f-b93b279e994d,Benfleet TSA (Teacher Training),,school,1JH,10033256,136579
+c46f72e4-0251-48be-90fc-d0f40f7327d8,Bengeworth Multi-Academy Trust,,school,2JC,10046169,140932
+aac4cb38-c65c-479f-b804-348a1d3b6382,Benton Dene School,,school,18O,10077003,108655
+c32de52b-e815-430d-ad55-3038a489a000,Berlesduna Academy Trust Teacher Training,,school,2D6,10057789,70094
+5f0acab7-f16e-4899-a8b3-1acb3349f108,Best Practice Network,Best Practice Network Ltd,other,6B1,10019464,
+374143c1-3e83-40e8-beae-a78a64ae97fd,Biddulph High School,,school,14K,10035123,137356
+f3ed971c-55d9-4297-bd47-c5c15dd6bcd1,Billericay School,,school,1PT,10034119,70094
+11350576-097e-4548-ac54-15ab7629a3bc,Bingley Grammar Teacher Training,,school,2BP,10000697,107439
+a547b187-0e4c-4e8d-92b7-20fb7636d8c9,Birkenhead North Schools Partnership,,school,2F7,10074953,105086
+f7aab2b2-fc77-40f3-8e24-2e56729a706e,Birmingham City University,Birmingham City University,hei,B25,10007140,133788
+340e2f91-a60c-42d0-a334-f583691df46c,Birmingham Newman University,Birmingham Newman University,hei,N36,10007832,
+75e3bee2-6fbc-4c6f-8a28-e9f999e7fcfb,Bishop Challoner Training School,Bishop Challoner Catholic College,school,1K2,10000722,103560
+305d3efc-af00-44f4-9a8b-77c735ccc290,Bishop Grosseteste University,Bishop Grosseteste University,hei,B38,10007811,133835
+2f78b2ed-dd25-4b1f-b123-2a3e93d1a2f3,Bishop Wheeler Catholic Academy Trust Professional Development Partnership (BWCAT Partnership),,school,1QD,10040645,139352
+eefec03c-6cc6-46e0-941e-0199d7f1fff2,Bishop’s Stortford Initial Teacher Training,,school,13E,10059068,137156
+ab770f58-2c82-45cc-ae2a-b0045be6469c,Bishop's Stortford SCITT,,school,26T,10059068,
+4f66c8a9-f0ef-4aa2-9c9a-f0b29855a50a,Bitterne Park Teacher Training Alliance,,school,1F6,10014998,116458
+bfac35a5-beb9-47b8-a4c3-8a9ac932cf87,Black Country Regional Training Hub - University of Worcester,,school,2BC,10007139,141712
+2660d7db-992e-41eb-afc6-6e986c93334f,Black Pear Teaching Alliance,,school,2HC,10060754,140933
+4fe14c6e-b666-4d8d-b932-32733ace03b2,Blackpool Sea View Trust ITT,,school,1XH,10043075,140143
+329d43ba-dc4d-4e68-8a7d-85986804b2f4,Blessed Christopher Wharton Catholic Academy Trust,,school,13K,10087141,148256
+93eebd22-25b3-43cd-9d26-02978757fadc,Blessed Thomas Holford Catholic College,,school,1YR,10015044,106376
+de41f80b-55a3-4022-a0af-23a2cca89c46,Blue Kite Academy Trust,,school,2HL,10061050,142546
+19cc2711-92c2-4171-b3d2-b674804005ba,Blue Sky,,school,21L,10007832,142205
+047a3ace-1d36-4a8f-8a13-41cee7567659,Bluecoat Academy,,school,12W,10052837,70305
+3e7832ad-f08a-4800-8bab-b7e0ab166545,Bluecoat SCITT Alliance Nottingham,Archway Learning Trust,school,1YH,10052837,
+9acec2f1-63d9-41bc-8728-43bf52664986,BMAT Education,,school,5B4,10059426,
+3e31b0c9-b309-4f45-98d4-c87b8dccd6f4,Bohunt Education Trust,,school,1DP,10033361,136643
+11ee09a4-2da5-4785-ae62-0f59bd524ffb,Bordesley Multi Academy Trust,,school,5F5,10059134,137167
+8197bac5-ad9e-416b-b9b2-5acb3e4e6ae2,Bosco Sussex,,school,1KY,10063488,144243
+005f56ac-9ab6-4543-b5b4-01a13be35041,Bosco with the University of Sussex,,school,5B3,10063488,144243
+d1aa9047-515b-40ca-a132-b44ed3962363,Bournemouth Bay Teacher Training Partnership,Twynham Learning,school,13Q,10056993,142671
+f2807fa3-e17e-41da-9e67-c9e849371158,Bournemouth Bay Teacher Training Partnership,Twynham Learning,school,B52,10055369,
+da8e6b57-cde6-4d6b-90eb-e8fbf2c2711f,Bradford Birth to 19 SCITT,St Edmund’s Nursery School,school,259,10047807,
+91257d36-fc6a-44fe-a86d-031be74f4cbf,Bradford College,,school,B60,10000840,
+6a9ad9cd-1086-44db-8c80-9259ce2e0a86,Bransgore Initial teacher Training (BITT),,school,19F,10035668,137693
+66bfe690-a3f2-454a-96fa-6ac95fc40830,Bridging the Tamar Learning Alliance,,school,165,10059114,137257
+b521db76-0eef-406a-b62b-e5e0bd321133,Bright Futures SCITT,Bright Futures Educational Trust,school,G65,10046414,
+21418d91-4da9-4d7c-bd8a-f32de1a1251a,Brighton Hove and Sussex Schools Alliance,,school,1KN,10007212,130668
+b1df7833-4bc9-4fe0-a469-97c0dc133751,"Brighton, Hove and Sussex Schools and Colleges Alliance with the University of Sussex",,school,4B5,10007212,130668
+3c60f145-2554-4d7a-bea3-ff7c2756f97a,Brigshaw Learning Partnership,,school,4B1,10057632,143238
+bfd451d9-d30d-4ab7-8f47-343029154f19,Bristol Excalibur Academies Trust,,school,6H5,10059937,145398
+719e80fd-8942-4052-b1c4-8cd7adbe8d24,Brockhill Park,,school,19C,10035076,137458
+ea43e3c9-10c5-4a2a-985d-3623b5416d35,Bromley Schools Collegiate,,school,B91,10059069,
+04d1503f-0e4c-46fd-a3b8-b14a5bc73c40,Bromley Schools' Collegiate School Direct,,school,1C9,10033362,136644
+fdb1c642-7020-4154-9385-2ce4b5661770,Bromsgrove Primary Partnership,,school,2HU,10080149,116665
+395e6215-ed40-4c19-9d03-7cc49db7387f,Bronte Academy Trust,,school,7H7,10061184,142948
+7f309814-a1c0-43bc-a918-12607a1dea07,Brunel University London,,hei,B84,10000961,
+2df15e6d-4a87-426c-a4e6-d1d606e162b5,Brunswick Park Alliance,,school,267,10071299,101264
+3f0c7b81-85e4-46d3-8f65-d27608e7bf9f,BTSA (Accredited by the University of Derby),,school,14D,10007851,136549
+f1515b9c-15bd-4a3d-bc46-1a02b367a43f,Buckingham Partnership,The Buckingham Partnership,school,B71,10035071,
+9bbaa33a-de6a-4aa7-864a-accff3e0c947,Buile Hill VA College SCITT,Buile Hill Visual Arts College,school,1WT,10057624,
+1ecbf295-8fb8-4844-9699-d7018a52afbf,Burnham Teaching Partnership,,school,1MT,10035483,137564
+6f4285bd-d0a2-4514-8024-4d0ff3290357,Burnt Mill Academy,,school,2GY,10035847,137694
+a058b1e8-ec38-482b-9d9b-24cb80530ebf,Calthorpe Park North East Hants and Surrey Borders Consortium,,school,1UH,10015239,116436
+b62ab94c-914f-40a3-8f2e-820b6ebc2eea,Cambridge Meridian Academies Trust & Swavesey Village College,,school,2KU,10033420,136580
+ef3ff08f-5b44-4ccd-9b4a-749517fda8c8,"Cambridge Training Schools Network, CTSN SCITT",The Cam Academy Trust,school,1WO,10055220,
+6299a7e2-005b-43ff-9d2f-b7df8b559346,Campus Tees Schools Alliance,,school,2JJ,10057507,143063
+cfc4576b-e749-4578-b72b-fa79d1cf6f3b,Canterbury Christ Church University,Canterbury Christ Church University,hei,C10,10001143,133806
+5072e8e8-f107-4fa9-9894-8e224df51a36,Cardinal Hume Catholic School,,school,198,10036181,137852
+921cf7f5-cad1-42a9-a59c-65205b12b4af,Carlisle Schools Alliance,,school,136,10034763,137369
+ebc181a6-a6f3-4e9d-854f-b89186e0a554,Carlton Academy Trust Teacher Training,,school,3,10083491,147100
+05c57c02-1c1d-44c6-a128-6d2ba2e37360,Carmel College,,school,1KF,10055116,137622
+0672bb62-e0d1-4ca4-bc81-9dbc683db258,Carmel Teacher Training Partnership (CTTP),,school,C23,10055116,
+94858a29-1419-4ede-8dd7-d580a6769664,Castle Hill School,,school,4C4,10054655,142420
+78b72be5-187f-4398-aa66-202b6719e88b,Castle Newnham Partnership,,school,29R,10007152,109661
+6c2953a1-d5c2-40fe-81a9-a2301bdea50d,Castle Phoenix Alliance,,school,179,10040289,139292
+cdb39932-a1ef-4183-85d8-8843fd61a083,Castle View Enterprise Teaching Alliance,,school,2FS,10027530,135818
+d758998f-813c-49ab-91f8-e9b4cd859dd2,Castleman Learning Network,,school,1RP,10046893,141184
+d9e00e30-d78c-4e0b-837c-c25f0b3ba681,CAT Institute of Education,,school,17B,10032964,136459
+c595e463-9d3a-45e0-8f68-aeaf4dc3a402,Cathedral Schools Trust,,school,2HN,10058233,135575
+57d683c6-af54-488b-8ca3-3694c1eb9d9c,Catholic Schools' Partnership,,school,134,10038068,138961
+455bda3b-ae52-4205-a6f4-b06a1a4e1fba,Central Learning Partnership Trust,,school,1VG,10035949,137730
+63345a46-1780-4f61-8298-724f5362dc74,Chauncy Training Partnership,,school,1RK,10034843,137090
+d49338bc-4e4f-4722-a48e-510c13fd4a3a,Chepping View Primary Academy,,school,138,10036917,137979
+f56fcf71-8b1a-460a-aab6-1577b1fcb1a6,Chepping View Primary Academy SCITT,Inspiring Futures Partnership Trust,school,24S,10059665,
+62b5ee43-ff67-4433-bb1b-96201a2d1a32,Cheshire East SCITT,Holmes Chapel Comprehensive School,school,25Q,10035146,
+03c1af98-132c-4b20-80d6-30a37dcfad8a,Cheshire Leadership & Teaching Alliance,,school,144,10038606,138742
+92267dde-ed22-4353-b8ce-8c4d500eb736,Chester Diocesan Academies Trust,,school,3C5,10045107,147810
+6bbc5fd6-9865-41ef-a56c-c365f3cd17b1,Chichester High School,,school,2GC,10043063,126063
+fe06d8dd-bd2a-4c48-8534-6e53af7d4807,Chiltern Training Group,Chiltern Learning Trust,school,C59,10055370,
+3a8170ea-3d75-4d5d-bcec-a08f0a120cbe,Chorus Education Trust and Sheffield Teacher Training Alliance,,school,1N5,10039996,139167
+85b19d99-61b5-4831-a60f-aecb21f70559,Chrysalis Multi Academy Trust,,school,5C2,10058610,136656
+6d2d9f3b-66b5-4b4e-a94a-0a750095cc29,City of Liverpool College,,school,L43,10003955,130487
+43bd2c47-49cc-4438-89ad-97b592cc762c,City of London Academies Trust (COLAT) SCITT,,school,4C3,10058170,
+844a4569-ac26-4517-8959-3cd55cf8728f,Cleeve School,,school,3B6,10033702,136772
+15bb2cf4-d764-405c-bcda-db1487fba92e,CMAT Stamford Welland Academy,,school,9J1,10035739,137600
+cb6e7aa9-df34-4454-a4cd-03d4fb48d271,CMAT West Town Primary,,school,1DT,10045926,140855
+490f6cca-b855-4c0e-b78c-3b43b74fcff7,Co-op Academies Trust,,school,2X4,10030216,136102
+fdba1da3-9ec7-41e8-96bf-406a97b4b754,Coastal Academies Trust,,school,4C5,10058585,
+d96b5b9e-a5f3-40d7-9d73-141ee0536795,Colchester Teacher Training (CTTC),,school,2DB,10035498,137515
+ad4758f5-ba30-4a19-b615-e56fd0fc8b06,Colchester Teacher Training Consortium,The Alpha Trust,school,C76,10035498,
+42417319-dd35-43d0-a961-6e787a8146a5,Colmore Partnership Training School Alliance,,school,19Q,10052836,103189
+85d740a5-e814-42e2-824d-2ecb8cc6d57b,Compton SCITT,The Compton School,school,1X7,10058414,
+ce03f568-eae2-4e84-9431-4cf9fb4f8401,Compton SCITT,The Compton School,school,19P,10032609,136418
+30c02648-eafb-4816-80fc-e19b031deb21,Congleton education Community Partnership,,school,29W,10046166,140981
+b4bce687-ed99-4f51-9f29-5abf271ea417,Connect Education Trust,,school,189,10057790,143201
+b6e46fad-4197-42c2-b5e3-acaa50d1f0cd,ConnectEd Partnership,,school,27U,10061610,143506
+d55c5ec5-efb1-441b-a441-16c0bb54f572,Consortium Multi Academy Trust,,school,2J7,10061190,145795
+54401a75-f095-4505-9c8b-322eca5e63c7,Cornwall Education Learning Trust (CELT),,school,4C8,10055139,147442
+282d6871-f974-4bd6-a06c-9210e587a8c0,Cornwall School Centred Initial Teacher Training. (Cornwall SCITT),,school,C79,10007063,
+505caf1e-ece3-4695-aba9-37b2fe85cdd5,Cotswold Edge Teaching Alliance,,school,26P,10034599,137123
+b907ac14-10ba-4ac8-9d1c-0fa181ff709c,Court Moor Partnership,,school,2J8,10015454,116412
+cfcb226f-a234-4fab-a772-9f8a63db6189,Coventry and Central Warwickshire Teaching School Hub,,school,1GH,10047140,141277
+07e65e50-e85d-4305-b427-cce2b53d8ede,Cranford Community College,,school,265,10033241,136522
+e4706ff3-b62f-431b-817c-ea0fb72f8067,Creative Education Trust,,school,5A1,10042706,139961
+bdec5ca1-666c-4666-a3cb-1e70b80e2cff,CREC Early Years Partnership,,school,25R,10033424,
+3cf40a98-421e-4aaf-8dfd-b8c8a695f647,CTSN@Essex Primary SCITT,,school,4000000,10055220,70249
+2a446247-d9d9-4537-98b8-6d55f76c8cda,Culcheth Campus,,school,4F5,10001791,111430
+2f1cd826-faff-4cbd-89ed-7f32370a9741,Cumbria Education Trust,,school,3Q2,10049508,141995
+3896d3bb-1d29-4ae5-b50a-9e924478a461,Cumbria Primary Teacher Training,,school,C97,10048041,
+36500d9d-4ec8-4141-bafb-58cef3c26815,Dacorum Schools Alliance,,school,1HS,10007147,138352
+64b02ce6-4952-46e3-9262-bbbab77b7d19,Danes Educational Trust,,school,3D3,10058906,136901
+9f1ad46d-5ebb-4df6-af2a-590c8a5be5b2,Darlington West Park Partnership,,school,1DB,10033825,137042
+377552e7-ff5d-4426-b199-ceaa8259dc3e,Dartford Grammar School,,school,29N,10032228,136359
+cdbc8e8c-ba17-447e-ac81-dc433a295ddc,Debden Park High School,,school,2AP,10033412,131876
+a2298448-4165-4f9a-9da6-2b3be1275091,Denbigh High School,,school,1D2,10032194,136319
+02f9444c-d040-45cb-a58a-4604c0ff9018,"Developing Teachers, Schools and Academies (DTSA)",,school,1Z4,10083346,146477
+227dd280-8f4d-411c-a1b4-619472bb4ee6,Devonport High School for Boys,,school,2LB,10033019,136496
+5b222887-8641-4aa5-984f-74e1330e87c3,Deyes High School,,school,1CD,10035012,137533
+19067436-b1dc-45f8-a07e-3b4f1acf015f,Diocese of Leeds BKCAT Alliance,,school,1ZX,10006270,108297
+c8e54f8f-8e2c-4dec-a3ef-7aa1ec2862c2,Diocese of Westminster Academy Trust,,school,2W5,10059577,137895
+6ca49a37-b3bd-4710-a85a-6bd39c26eb5e,Diocese of Worcester Multi Academy Trust,,school,6H6,10064288,149476
+e9fc87e4-ac19-4e32-bdbb-96b33d2b7e5f,Diverse Academies Trust,,school,12K,10034870,137319
+b9d595f6-4afa-406f-8772-878385dcf896,Dixons Academies Trust,,school,1EP,10001992,130909
+5d9b6196-903e-4652-b869-fa3a37e55381,Doncaster ITT Partnership,,school,D51,10002008,
+ed74c5e5-697f-4c9a-89b1-6e1da2ffbdaf,Dove House School Academy Trust,,school,1SG,10034865,
+edfd50fc-4f54-4d0a-be4f-1a28d082867d,"Dover, Deal and Sandwich Partnership",,school,1CG,10032210,136317
+3dd7d347-fba7-486a-9c92-d451bbb6f7d3,drb Ignite Multi Academy Trust,,school,5D3,10060889,
+a6b7102b-8152-4424-8678-698f227fe2aa,Dudley Academies Trust SCITT,,school,4D1,10066093,
+724934b9-69e3-48ee-9f90-1aaaec6e6bae,Dulwich College,,school,3D1,10015447,100861
+22b107d8-7a75-48fb-83f5-f35a1fb318b9,Durham Johnston Comprehensive School,,school,4D3,10002066,114312
+d23f377b-17c7-4443-b093-061c84159a39,Durham Schools Together,,school,2DP,10072165,114080
+f280088a-9a38-4a1b-b47d-d433436ab2bf,Durham SCITT,The Eden Learning Trust,school,D87,10067657,
+147da625-f945-4bee-b454-a96ad2bbde7c,Durham St Margaret's,,school,2FF,10073790,114230
+63c46a68-1bf8-4434-a86d-2a56e8b691cd,Durham University,,hei,D86,10007143,
+7f6b0a3b-9e21-433b-ab35-0e06007b2feb,E-ACT Academies Trust,,school,1Z1,10028140,135907
+42884498-6141-41d9-8b77-ac6dc8e15597,e-Qualitas,e-Qualitas Professional Services,school,E69,10046623,
+b0517147-4e09-450e-a059-d3b6a767db4f,East Herts Partnership,,school,1VT,10035495,137532
+2b08fa73-8e1f-4b4d-80d8-fd63d4cc3fcd,East Midlands Teacher Training Partnership,East Midlands Education Trust,school,E31,10055367,
+2b76a55f-580d-4087-b8b8-79be7fa51348,East of England Teacher Training,,school,2B6,10052840,
+76eaeec8-6995-4e39-9f81-40220cbb5a14,East One Partnership,,school,E1P,10078399,107249
+3d8608d7-f2ce-47ea-9a87-5a1164b67395,EAST SCITT,East Anglian Schools Trust,school,3C6,10058884,
+eee105f0-e576-44b4-9d19-bfa4494bb18c,Eastbourne Area School District Alliance,,school,1J5,10015514,114592
+1378a2cd-9d89-4220-aa35-1737aa3cbbf0,Eastbourne Area School District Alliance with the University of Sussex,,school,3R2,10015514,114592
+114d6cdb-17c6-4995-a698-cd621e7b06b4,Eastwood Park Academy Trust,,school,2G1,10034832,137284
+8124d69c-86c5-45e6-8d5f-f45843c3b489,Eatock Lead Partner,,school,2GV,10070107,105202
+5662f26c-1034-4b7b-a842-4cb2ef0a7ede,EDEN Academy Trust,,school,50,10060479,
+dfd3335c-f1ac-479b-a9c9-9181526c58d4,Eden Learning Trust,,school,2LW,10067657,138717
+6af36871-94b9-46f0-8a10-27ae25bb7665,Edge Hill University,Edge Hill University,hei,E42,10007823,133828
+466f9df5-7e54-401a-812f-fda6c3d86008,Educate Group Initial Teacher Training,,school,E65,10035411,
+a8a9abcb-793a-4823-bee1-d414cff44554,Eleanor Palmer Primary School,,school,14F,10078057,100027
+f650df15-1cf6-4e66-86c7-123127c0ed54,Elston Hall Learning Trust,,school,2JA,10061031,142349
+bb85715b-a136-4f5c-95c0-327623d55fa1,Embrace SCITT,The Sea View Trust,school,400000,10062373,
+81478a11-ce1d-4bfd-806f-8eccda96b2ec,Embrace SCITT @ Endeavour Learning Trust,,school,M70,10059445,
+839c41c8-5193-487e-a882-91fa466ac88c,Embrace SCITT @ LET Education Trust,,school,P38,10060518,
+45791a6c-6b17-4c4b-8de9-e6b1db0111fc,Embrace SCITT @ Rowan Learning Trust,,school,3R5,10059724,138110
+eb9d1544-868f-4184-b5f7-2c2461af26f4,Emmaus CAT ITT,,school,40000000,10086423,133826
+466704c3-29d3-4bbb-aaae-9f3ed0e77776,Endeavour Multi Academy Trust,,school,60,10058938,146727
+8cfbe762-4c56-46e8-a6e2-79f056cd984f,Enhance Academy Trust SCITT,,school,3000000,10036918,137967
+eb8bbd65-a02b-4cb2-bd73-7c2969301827,EQUA Mead Futures,,school,2Q4,10058424,
+552b8eff-38bf-47e7-a61c-eb84406e6cee,Esk Valley Alliance,,school,1XT,12345678,121610
+916da492-c3af-4bfe-a99d-0891892edc2f,Essex and Thames SCITT,Essex and Thames Education,school,T25,10034267,
+9645b161-754c-47bc-9f33-aea85a4bb425,Essex Schools ITT,,school,1OS,10035578,70275
+05fa1df8-5145-4cbc-bc14-5f7c06d94857,Essex Teacher Training,,school,E75,10002327,
+8faecace-20d2-4ce8-9878-59191cb66e74,ETT@Northern Education Trust (NET),,school,1UR,10055739,147541
+65a51f45-801a-4768-adcd-12682b932fe3,ETT@Tykes Teaching Alliance,,school,2C3,10043460,140242
+cb147632-b8ca-4019-8bc9-50088d06d91d,Excalibur @ St John’s,,school,2BO,10038597,138623
+6fdfb229-ed4c-4193-9e4e-8afb5d6dc729,Exceed SCITT,Exceed Academies Trust,school,2EY,10064216,
+d54ad80c-4239-4431-8146-32e05320f1e8,Exceed Teaching School Hub,,school,278,10057431,143096
+01c15419-236a-430e-89aa-2eccd96e6b9e,Excelsior MAT,,school,8F8,10060213,146696
+e946d469-b706-42fd-a3ca-090e4eadb829,Exchange Teacher Training,Delta Academies Trust,school,1DU,10055739,136343
+3f645b07-4866-41c3-9e0b-dd816fe2baa3,Exeter College,,hei,40000,10002370,
+c77aa2c6-3f51-44d2-88fd-eb2876da6b02,Exeter Consortium,,school,1QX,10063074,144072
+feb280f2-a275-4678-aaf6-d0e476825210,Exning Primary School,,school,1JM,10072937,124544
+9bc79f3d-122f-4792-88ce-0c05399ee4a6,Extend Learning Academies Network (ELAN),,school,2DT,10065038,144918
+ca6c2799-ca20-4805-9d96-982cb4c662bd,EXTOL SCITT,,school,500,10060484,
+54edef8f-31cd-4752-a005-0587e2641433,Fairfield Infant School,,school,1VQ,10080422,124582
+ae4206ed-87ed-4323-9985-fbe73c6a60ba,Fareham and Gosport Primary SCITT,Harrison Primary School,school,25M,10048033,
+0ab92bd7-ae87-492a-b196-936b070b58f2,Fenland Alliance,,school,1XY,10007152,110632
+a033453d-2c50-4632-bd63-9c92c76ffc67,FIPC (Hazelwood Schools),,school,15T,10046090,101997
+4417fb1d-b4e8-40cd-af9f-e3494539ccb5,Five Counties SCITT,Cabot Learning Federation,school,4C1,10049578,135959
+a9b738f3-5c37-4ce4-a5c5-b4bfa8158c38,Five Counties SCITT,Cabot Learning Federation,school,2AV,10058211,
+95fb2fe2-84ff-4820-b437-4313af0b1e67,Forest Independent Primary Collegiate SCITT,,school,F82,10046090,
+67b2b824-a4d7-44fe-a3cf-960abf6c681e,Forest Learning Alliance,,school,1HW,10068903,109847
+41941a79-fa17-4bf4-9c5a-2b299b9bcc10,Forest Way Initial Teacher Training,,school,1L8,10036610,137905
+8cb25e34-26f6-4f26-9515-a0b2b9b3bdc8,Forty Hill CofE Primary School,,school,2L8,10073980,102028
+7fa93599-0e7a-422e-a92b-77f3661bff94,Forward Education Trust ITT,,school,1MR,10007166,144042
+032973a2-cb1a-4c71-a722-e059ffeac9b4,Frank Field Education Trust Be More SCITT,,school,4F3,10081880,
+b117f6c7-d6ac-467a-9a5b-e8f0ebce8eea,Futura Teacher Training,,school,3F5,10059285,137523
+5afc1e86-578e-448c-a797-5b45655eb023,Future Teacher Training,Future Academies,school,P58,10043978,
+f2c29709-b601-48e5-8b9b-7523034c65b3,Futures Teaching,,school,2KR,10043454,140248
+dd10dc0d-09f2-42cd-9717-e1bdf75120fe,Gateshead Schools Direct,,school,1EW,10090323,149052
+583cc24c-2fc2-4792-8ce3-3ef10c9bdd52,Generate Teaching Hub,,school,15R,10057459,143064
+13fadb7f-7bf6-4470-8e01-2e9b218ca765,Geoffrey Field Junior School,,school,1QL,10079852,109781
+5c57b01a-2529-4155-8531-cf9b1d45aa56,George Abbot SCITT,,school,G12,10055368,
+23ee3c7e-b906-44f4-aa9f-6cd9b8e00bc1,George Abbot SCITT School Direct,,school,1OV,10055368,136906
+e0aa516a-07d7-4acc-bd92-defbcc4e4dec,George Spencer Academy SCITT,The Spencer Academies Trust,school,1HR,10058352,
+14fa5323-ca8e-422e-a252-2a5ecbe9857c,Gladesmore Community School,,school,1FW,10002675,102157
+ae8fb382-7282-4598-bac1-4db5907953da,Glenthorne High School,,school,17J,10034150,136914
+4a241663-fb78-401f-b9c4-1df7a7e6ec1c,GLF Teacher Training,,school,2B4,10053217,
+c7f9d897-173e-4f2b-950a-1ae78a2d41cc,Gloucestershire Initial Teacher Education Partnership (GITEP),,school,G48,10034789,
+9784a5e9-fb04-433c-b015-85c1bc4a61c1,Godalming Learning Partnership,,school,2JT,10072769,125014
+af001d1b-d03d-4c85-a46b-993fc2a5ec18,Golborne Trinity,,school,A7D,10015405,106525
+12878ab7-ab91-4fdb-84f1-1978d4557061,Goldington Academy,,school,2DM,10033281,136552
+cf567b44-69f8-42b3-b02b-e032d12caa6d,"Goldsmiths, University of London","Goldsmiths, University of London",hei,G56,10002718,
+02267238-bf51-4e1d-aa76-03162eb1bcce,"GORSE SCITT (Leeds, Bradford, Hull and East Yorkshire)",,school,1N1,10055363,
+32fa3b26-7c5a-425a-bbe6-64050f8466fb,Greater Manchester ITT St Patrick’s Centre of Educational Excellence,,school,18A,10018025,105986
+0a836b20-7a6b-44f1-89c9-2783eae611f0,Green Park Primary School,,school,2F6,10070130,104884
+39d5adf1-908c-4638-b62f-8fdb443a3123,Greenheart Primary Teacher Training,,school,4G1,10060124,139002
+9d41452d-e2fa-4018-8100-e4e23e86c1d3,Greenholm Primary School,,school,19R,10038624,138693
+adb76031-4c5a-49ae-9d90-6edaf79416b3,Greenwich Learning Partnership,,school,185,10006893,100190
+343e864a-2f7b-4715-8d2d-c85a3c111208,Greenwood Academies Trust,,school,1EX,10034998,137184
+249b32ee-78b0-4bbb-9edd-a60dda1de999,Grey Court Training School,,school,22S,10039056,138825
+70779be0-fc14-4da1-bbca-0a4f2680a408,Growing Expert Teachers,,school,2AO,10005959,139471
+e392ca41-5228-4290-822b-3ec171764293,Haberdashers’ Academies Trust South,,school,1KP,10058159,135073
+5dc8cdd6-2a1b-4831-b09d-11ea7037bc66,Hackney Teaching Schools' Alliance,,school,1V9,10078024,100250
+26e2fc8d-d852-435d-bc4d-85a555b053b3,Hagley Catholic High School,,school,7G8,10047639,141414
+74343cd0-2f08-4726-895c-eb3bb048bdc0,Hales Valley Teaching Hub,,school,18E,10061958,143821
+c61abac2-e57b-4f93-9bd9-16d59e7eab1a,Halstow Primary School,,school,1V5,10063110,143597
+bff2b677-1dcd-4623-9799-a3a4a5932a81,Halterworth Training School Partnership,,school,1A8,10086663,148216
+fa7d8179-fc48-4d2a-9ddb-04b2be7e033b,Harris ITE,,school,1WU,10055126,
+33eda2f4-1e56-4e91-b61b-68b28f090403,Hartismere School,,school,1GP,10031385,136271
+a80b24ad-4dc2-4ec0-aff2-e61611e84291,Hastings and Rother Alliance,,school,1L9,10017797,114612
+1b365db4-8212-4a36-a401-85f33d4df03b,Hastings and Rother Alliance with the University of Sussex,,school,4H2,10017797,114612
+c9a38447-c034-46ba-bdbe-ccb51980c2cd,Hatton Centre for Education,,school,1Y7,10036614,137912
+84280f79-9618-47af-8e97-65da89f61e74,Havering Train2Teach,,school,178,10069441,132776
+631babac-da8a-482e-bc0d-ec8937597a71,Haybridge SCITT,The Four Stones Multi Academy Trust,school,2B3,10034167,
+02dae7e6-d0e5-43c9-a176-dc4723113e47,Henry Maynard Training E17,,school,2AW,10053211,
+1d0051bc-1c18-4d4f-88b5-377f3e883b7f,Hereteach Alliance,,school,22V,10062355,143929
+f0571cee-eeac-4bb0-a11f-6ca457cfd63d,Heronsgate Primary School,,school,1EE,10078039,100158
+f166e5c4-186d-4e1b-855c-c173a28d54b1,High Force Education (SCITT),,school,H38,10046049,
+eed73087-fcea-4f76-8d7a-9c6d36f214de,Hillingdon SCITT,,school,2B5,10059208,
+d0310be4-c527-48be-9549-462955265839,HISP Teacher Training,,school,1X9,10033571,
+cb215a64-cc20-463e-97ce-42f798929fe2,Hitchin Boys' School,,school,1QY,10039989,139154
+dadd7732-6271-4d06-94cd-7118f9dbe1b8,Holy Cross Catholic Multi Academy Company,,school,6J6,10084072,147345
+0219e7ec-92fa-4898-a1b1-dd31ea95dd11,Holy Trinity CofE Primary School,,school,292,10073971,102418
+2fad2f3b-b350-4824-bde0-7b17a1938fa8,Hope Sentamu Learning Trust,,school,1DH,10058624,136544
+473dea6c-42c8-4029-8cfd-c00c82e52661,Horizon Academy Trust Teacher Training,,school,1OL,10044816,117814
+3d23bc11-45e8-4693-a602-4e23f1e6013f,Huddersfield Horizon SCITT,South Pennine Academies,school,2EX,10058690,
+f0712fbb-cf69-48ca-888a-9fa576004b3a,Hudson Primary School,,school,2F5,10069137,104869
+20a41b34-8593-4d0d-9f23-4fa2947dcd84,Hull SCITT,,school,25O,10055359,
+f383db0a-84aa-47a7-b3b8-a609bf246330,Hungerhill BFLPT,,school,298,10036542,137899
+db3fec4e-92c4-4fed-bc5f-32fca60a28f7,Hursthead Junior School Alliance,,school,27X,10046173,140925
+9a73e1f9-68e7-4191-8c98-18cecf39211b,i2i Teaching Partnership,,school,24X,10058582,
+44fc1ec5-22b2-4ae1-b45c-b454f8caf418,Ignite Institute,,school,22A,10046195,140896
+ca4a5043-6cf1-4c00-8724-cc0b4093502c,Ilkley All Saints' Teacher Training Partnership,,school,2DX,10068642,107309
+b2a98436-c6fb-4b60-ad2b-d92e677a192b,Illuminate Minds Trust,,school,8C4,10040974,
+54b56d09-9f08-4088-92e7-4d4138be40fb,Inclusive Schools Trust,,school,2JE,10064197,144144
+f5875ccd-894f-4194-ba91-a626ad112ea8,Initio Learning Trust,,school,1I2,10060921,141757
+74589043-6feb-4fda-b307-efc6b17d3c30,Insignis Academy Trust SCITT,,school,3I5,10034108,136845
+6763eef1-bc29-4f16-89fd-8c7160c0f6ff,Inspire Education Trust,,school,3I2,10061026,143535
+172b3fef-9319-4ab7-804e-73fdf171b978,Inspire Partnership Academy Trust,,school,5I2,10064647,
+228088da-e0f0-4afd-bf05-27e071433c7a,Inspiring Future Teachers,HISP Multi Academy Trust,school,3Y3,10058640,
+dcaa8c60-d95b-4d1c-a120-c01ddc58a4a4,Inspiring Leaders - Teacher Training,Inspiring Leaders Ltd,school,3A1,10088528,
+e5a84096-368e-4e5b-89c2-1ff358835504,Inspiring Leaders Primary (Derbyshire),,school,5W1,10088528,148428
+d02a9153-3edb-47d2-a867-7fcc212fe464,Inspiring Leaders Primary (Leicester and Rutland),,school,1BJ,10055365,
+e2b6cccc-50d0-439d-9d63-008a9a33c421,Inspiring Leaders Primary (Nottinghamshire),,school,24H,10088528,
+7375156f-e4b2-4050-91da-b81973628d2d,"Inspiring Leaders Secondary (Leicestershire, Rutland and Northampton)",,school,4R4,10088528,
+5558404b-8de5-4c72-9b5a-ef4d15efd94d,Inspiring Leaders Secondary (Nottingham and Derbyshire),,school,2A5,10088528,
+f8658bea-353d-4ac5-b854-0b8cbe83337e,Invictus Education Trust,,school,2I2,10047463,141342
+797c5850-b3cb-43c4-acc8-06b87c3c999a,Ironstone Academy Trust SCITT,,school,3I4,10060801,
+6f52c8f2-0ffa-483e-9ff1-5c60645fb594,Jewish Schools Direct Primary Consortium (LSJS),,school,1CP,10082385,146663
+3b6a665f-d03b-4c56-8591-9bf33ac72c8a,John Donne Primary School,,school,1DS,10044489,140507
+8f34db2d-77da-4333-90df-8d318f6899d5,John Taylor High School,,school,1L6,10032188,136323
+90024f78-7f9a-476c-a99d-8739818d2e95,Josie Thirkell Institute of Education,,school,1GW,10048068,141563
+90ca45e6-702f-4e67-bcfd-a4ed2289cd10,Keele and North Staffordshire Teacher Education,Shaw Education Trust,school,24J,10060817,
+7cd838a5-6672-4f50-8ccf-834f0d9d6834,Keele and North Staffordshire Teacher Education,Shaw Education Trust,school,5S3,10060817,146635
+8bce8a16-879c-4cd0-b835-e70962ca873f,Kent and Medway Training,,school,K30,10052832,
+778339e7-0693-43b2-8352-1b6bdde95bc8,Kent Catholic Schools' Partnership Initial Teacher Training,,school,4K1,10060024,141217
+049c148d-0291-42f7-aec5-9389f6d7fb83,Kent Oaks Consortium,,school,2CC,10030458,136128
+ca959eb8-4ece-4c4b-987d-6ad3ab37668e,Kent Oaks Consortium with the University of Sussex,,school,2O2,10030458,136128
+5b842429-f2cd-48bf-aee2-0ff8725d3d9e,King Edward's Consortium,,school,K50,10065300,
+44a6a97c-c2f2-4d5b-b74f-f2a64281af58,King's College London (University of London),,hei,K60,10003645,
+af7a5d46-69a7-45c6-a7b2-19a71813ce57,King's Group Academies,,school,1AS,10063058,144093
+5b0609a6-0f04-43ca-9600-e43ef7531c16,Kingsbridge EIP SCITT,Community First Academy Trust,school,1S2,10054033,
+e62369a5-7d57-4d16-98cb-fddf3e7a023b,Kingston University,Kingston University Higher Education Corporation,hei,K84,10003678,
+cde0b61d-97ad-4584-a982-7cf2881c02fb,Kirklees and Calderdale SCITT,,school,1WK,10003692,
+0c43216e-9540-4514-81f5-89a59a88d299,Laidlaw Teacher Training Partnership,,school,4B4,10005732,147670
+e37d0d66-8951-4870-b694-b66de784ef91,Lampton LWA SCITT,,school,2AY,10031352,
+a7044391-1de4-40da-ae43-f39ce6f1d731,Landau Forte Teacher Training,,school,186,10018562,135120
+6e8723d3-a4ef-457c-b688-7e584d59c565,LDST North West Teacher Training,,school,4L2,10060879,143457
+f92bab0d-b1ce-4fba-9093-62ebc89e7c32,LEARN with FA1,,school,3L1,10060074,138851
+dd6ce385-7db7-4ae2-9b25-f7d7ac94081d,Learn-AT School Direct,,school,237,10007796,145203
+fd5d8264-a195-41c4-b295-73f9a110cf2a,Learners First Schools Partnership,,school,1GX,10045188,140646
+8c9524ce-ec4b-4488-bec5-78915db8dd66,Learning In Harmony Teacher Training,,school,2H5,10046984,148825
+b422d5d0-1f27-43e3-9243-44df1103314b,Leeds Beckett University,Leeds Beckett University,hei,L27,10003861,
+32b7ec65-65f7-42f9-a9b4-2287bb7c793b,Leeds SCITT,,school,L26,10003863,
+5c42e17e-0c3f-4593-ba7e-aad362838d2a,Leeds Trinity University,Leeds Trinity University,hei,L24,10003863,133838
+d1682905-f839-4eb2-b820-ebdaff3fe34c,Leicester & Leicestershire SCITT,,school,L35,10046132,
+ac82064a-7143-4963-a21d-6c3b31b612db,Leicester & Leicestershire SCITT,,school,L33,10055113,
+13e98c52-9b46-4220-95ce-3b2fac082fd7,Leicestershire and Rutland Initial Teacher Training,,school,5L3,10024318,
+63d9003d-6c0f-4f47-b243-2363c1e59f4a,Lift Schools: East,,school,2CG,10033736,138982
+1a8e8524-a829-452a-9b4e-cd422cebcded,Lift Schools: London and South,,school,2CH,10033736,138982
+2c8fcfcb-ac2a-42d7-8808-3b4f4a897a5f,Lift Schools: Midlands,,school,2CJ,10033736,138982
+9d4681e3-95f4-49f0-8293-c138f0b853c5,Lift Schools: North,,school,2CK,10033736,138982
+facaa96c-8b75-42f3-8b7f-6da861ca3772,Lift Schools: South West,,school,20,10033736,138982
+74c6236c-c401-402b-b3a1-01b8b30b5f7f,Lighthouse Learning Partnership,,school,16Z,10058855,16340
+f4a0edc6-492d-4c2d-8960-84f6e8f981ac,Lime Trust,,school,3L2,10060895,141734
+5b012bb8-2e9e-4e49-bef1-5179c09d1241,Lincolnshire Gateway Academies Trust,,school,3L7,10059809,
+4c279a8b-dfc9-461e-8932-231975091868,Lincolnshire ITT,,school,25G,10058228,
+564dc553-f5ec-480d-b0ec-5cc1cf3b47c2,Lincroft Academy,,school,235,10065849,136471
+bbd48b8d-8a4e-4326-b84f-90974a63d70c,Lingfield SCITT,,school,6L2,10059742,
+05fc8972-f35f-4786-a8f8-3b8ee0c85ab8,"Linwood Training, Support and Advice",,school,1X3,10017916,113961
+a636e2d4-f276-46cf-8747-5918e20f91ac,Lionheart Teach,,school,1O8,10055191,139624
+cdf72222-0a27-413d-ad89-b95b117661a7,Little Lever Train to Teach,,school,8J8,10024318,142296
+63f17351-e301-4b61-8dad-f63f34e4c135,Littleton CofE Infant School,,school,2HR,10079622,125231
+4fc25de7-21d4-4ed1-856d-7174765bca33,Liverpool Hope University,Liverpool Hope University,hei,L46,10003956,133826
+2ccb641f-380e-4ded-be58-f1b024ec5db8,Liverpool John Moores University,Liverpool John Moores University,hei,L51,10003957,
+7ee5229d-d0e8-4abd-a6af-41c4dbbb559c,Liverpool Teacher Development Partnership,,school,2T3,10006188,104715
+5693b1e9-ea62-4964-af0c-83b30ec4557e,London District East SCITT,,school,24M,10064183,140998
+5885c110-3192-43d5-83c4-2758723aed02,London District East Teaching School Hub,,school,5U5,10064183,143881
+981f4449-01e9-4894-a982-51c32d87fac3,London East Teacher Training Alliance,,school,133,10064599,144236
+0ef0aec6-1a79-40c2-b7ee-b77d544825bd,London Metropolitan University,London Metropolitan University,hei,L68,10004048,133816
+97ee3c63-2276-4e72-9816-2d2e119a68e7,London School of Jewish Studies (LSJS),London School of Jewish Studies,school,28T,10029147,
+90e640cf-e4d5-4f6b-975f-9e59d5c63014,London South Bank University,,hei,L75,10004078,133873
+756b8769-1c92-4e03-b9fb-21aa9fdc8d1d,London South Teaching School Hub,,school,8L5,10056990,142178
+414d90e2-ee9c-476f-b8d4-8c9405d2b7a3,London West Alliance ITT,,school,1P8,10031352,136341
+73228db5-3fe6-420d-bd21-8bd681a06d86,Loreto Grammar School Lead Partner,,school,1H2,10038100,138464
+cc512eab-da06-4846-bd70-c6fc4e7b8008,Loughborough Learning Alliance,,school,195,10017095,120352
+7db42208-77d0-49d6-9350-71994330e783,Loughborough University,Loughborough University,hei,L79,10004113,133834
+d9c56d38-6a1d-4226-9b49-9bf8f847a276,Lumen Christi Catholic Multi Academy Company,,school,6Y6,10060961,141835
+121008b3-f0fa-46e2-a292-3495a69b530b,Magnificat Partnership,,school,2L1,10052836,141063
+b62edd03-3a5a-40b2-adaf-121a853e8645,Maiden Erlegh Institute,,school,1Y1,10033353,136637
+134f12ba-a0c2-4f17-bd1c-3d38901ab8ca,Manchester Metropolitan University,Manchester Metropolitan University,hei,M40,10004180,133844
+0eb44a4e-fa86-4faa-b0b4-7709da35f2ba,Manchester Nexus SCITT,The Cranmer Education Trust,school,2EU,10058966,
+b2099505-7f52-409b-8df5-a4700c7f0c79,Manchester Prospere Teacher Training,,school,3D2,10046414,139148
+05e9c4ed-730a-47a7-a698-9476355534d5,Manchester Trusts and Schools Alliance,,school,1JR,10063039,144131
+aaddcfa7-ea5a-4409-8d43-ef1624245fc8,Manor Primary School,,school,1QO,10053803,141858
+259d8221-c748-4472-afef-e730ba996ea5,Maplefields Academy (Mainstream and Special Needs),,school,21F,10065849,138634
+ef158a7a-227f-4453-a415-6a346e156627,Marlbrook Collaboration of Schools,,school,1Y2,10070800,116684
+1646d32a-9981-4355-9552-6c8c367573ae,Medway Valley Training Partnership,,school,1Q5,10035084,118923
+4d174904-26f1-4a5a-806a-815dbc233257,Melrose Learning Trust,,school,4M2,10034923,136988
+646cdaf1-9754-4958-8f0a-a3ebe5e73367,Mersey Boroughs ITT Partnership,St Mary & St Paul’s CofE Primary School,school,1X8,10045107,
+c196354b-e23b-4711-a4c7-caf6d338312f,Mersey Boroughs ITT Partnership (Lead Partner),,school,17Q,10045107,104453
+563b020a-719d-430a-b470-ba8ccdd4d9cd,Merseyside Special Schools Alliance,,school,27B,10077028,104751
+85182ce8-991c-437e-8103-bd853a0f35ec,Mid Essex Initial Teacher Training,Bridge Academy Trust,school,M82,10058864,
+56b8f4c8-c491-4d5c-b113-1fb8569158cd,Mid Somerset Consortium for Teacher Training,Wessex Learning Trust,school,M84,10058347,
+855e0ec9-9a16-46bf-8b9b-5e9b80f0628b,Middlefield Primary Academy,,school,1C2,10038094,138595
+170908f9-1813-4651-82b8-82cdfd924a19,Middlesex University,Middlesex University,hei,M80,10004351,
+7f474fac-c740-45fa-8e47-a041d0d205d3,Milton Hall Primary School,,school,2M1,10069673,115313
+4a4a4a3c-81a3-4f4f-9aec-ad0cd020d39c,Morley Exceed Partnership,,school,2ER,10054666,142452
+9b087612-bce9-4834-85eb-5746d38bc19d,Mornington Primary School,,school,2K4,10066979,145536
+13a37787-6bc3-4021-bf76-91bb32a43b74,Mortimer Primary School,,school,9A8,10072196,108673
+db511abb-8fe7-41ce-81ff-4002f1436b14,Mosaic Schools Learning Trust,,school,8A1,10059391,
+eadbcb8f-d8ca-4236-ac83-47365714885e,Mowbray Education Trust,,school,8H9,10059338,137617
+28f51cee-727b-4353-a8f4-c046c40ec304,Mulberry College of Teaching,Mulberry Schools Trust,school,1CW,10061562,143629
+e8a78404-988e-46a2-b773-d79dd12fa004,Mulberry College of Teaching,Mulberry Schools Trust,school,5V5,10064234,
+bee164d0-7080-4565-9fb2-d5000991f758,NEAT ITT,,school,1L1,10064236,108526
+08d205e5-ca37-490d-8bda-02926a2c0beb,NELTA,Beacon Multi-Academy Trust,school,251,10059409,
+b23048de-d271-4950-ac93-4ef970c7e599,Nene Park Academy,,school,6N8,10034976,137082
+35924314-c5e2-4c40-a1b6-9be53e1559cd,Newbury ITE Partnership,,school,1RM,10038188,138525
+9088be52-9291-416b-9428-5a3efb1769cb,Newcastle University,University of Newcastle Upon Tyne,hei,N21,10007799,133852
+2a69d011-5f11-47e9-b807-1dd97ecf421a,Newham Community SCITT,,school,4M4,10068263,
+db0fc9f4-62b1-43b0-9c80-dfdb3fadf03b,Newport Junior School,,school,175,10064119,116234
+09f82057-4ef6-46b0-a5a7-238e3abd62bd,Nicholas Postgate Catholic Academy Trust,,school,2DW,10053805,142282
+afbeced9-e8a6-463a-b030-2890e18d9e91,NIoT: National Institute of Teaching,School-Led Development Trust,other,2N2,10090839,
+68670653-5fbc-4edd-9a08-e6b6dd8822cf,NIoT@Alban TSH,,school,1MN,10058506,70182
+2ac831ae-6c3e-4d33-b767-5da5bb2e68b3,NIoT@Colyton ESW,,school,4C2,10032336,
+67136483-f9b5-47e9-89c7-d7cae7d1f90b,NIoT@David Ross Education Trust,,school,1FE,10007149,137200
+32f66867-bb5d-4a6c-8abc-db7649beeaba,NIoT@Harris Initial Teacher Education,,school,1TZ,10090839,135311
+f51a1f99-c4d5-437b-b81c-57edc9fe909e,NIoT@Inspiration Trust,,school,2H7,10090839,
+f3c5749a-c808-4603-aa7a-a70e3d904523,NIoT@Kernow Initial Teacher Education,,school,21J,10007792,136312
+9f94f5d9-cea2-411a-8695-c2c390812f57,NIoT@Laurus Institute,,school,4L3,10054410,
+06ece6ab-6b86-478d-9e3c-ef4efb88bd85,NIoT@LearnAT,,school,5J5,10007796,133832
+5cf9882e-cc3b-4ca5-95ef-b9c67d5749b2,NIoT@LEO Academy Trust,,school,4L1,10058553,
+e9b783d4-6781-43af-8596-34141030f55b,NIoT@Liverpool,,school,3L4,10090839,141565
+33d90659-ff92-4c55-b61f-5b7d00be6808,NIoT@North East SCITT,,school,L06,10052835,136451
+ee76ce32-e773-4ffd-92e5-51249a2eb2a6,NIoT@Oasis Community Learning,,school,7K9,10090839,139128
+e119035b-e063-4474-80ce-b7494151081a,NIoT@Ormiston Teacher Training East,,school,3P4,10090839,
+0387ec26-453f-4c90-b9e8-8582c1c64314,NIoT@Ormiston Teacher Training North,,school,24P,10090839,
+d6fc3344-2fde-45a2-ba15-42398afea586,NIoT@Ormiston Teacher Training West,,school,2P4,10090839,
+c2d21e18-c451-4094-863b-ac99925a8da4,NIoT@Outwood Grange Academies Trust,,school,1GV,10090839,135961
+db77fcf3-d0c6-492b-801e-57bb37e5a10d,NIoT@Pen Green Centre,,school,21P,10034200,131232
+03175f23-64a7-483b-9cbf-e5867e92e53a,NIoT@Star Academies,,school,2A6,10090839,141565
+9995e4d0-1ede-4859-92a2-5bf24a428266,NIoT@Star Academies Graduate Apprentices,,school,5A6,10090839,
+0e542f69-2a5e-4e34-aa2d-eb67e20c561f,NIoT@The White Horse Federation,,school,4W2,10034817,137160
+8da0e4b5-2681-4026-890e-63effd52a566,NIoT@Trinity Institute of Education,,school,1YF,10029939,136094
+46489d32-64ec-4009-b8b1-99aaadf25568,NIoT@Unity,,school,2U6,10058379,
+a4fb5941-820c-4fec-9cbf-c9f183950ac1,NIoT@Windsor Academy Trust,,school,2HE,10058502,136618
+586e038b-bcc8-4b13-a42f-4eaf32573234,"NITE: National Institute of Teaching & Education, part of Coventry University Group",,hei,C85,10001726,
+79bf3486-cc99-49de-a42a-297b1d39ea41,Norbury School,,school,3N2,10080043,102222
+cb58e82a-0f1d-4e8d-811f-61186742bff7,Norfolk Teacher Training Centre,City College Norwich,school,N43,10004772,
+5ec9b8ad-0379-4a1b-8142-8acb8856f2f6,"Norfolk, Essex and Suffolk Teacher Training (NESTT)",Suffolk County Council,school,S14,10006399,
+e4aae01d-4aa1-4ee8-9af4-ee3165cd45ac,North East Partnership SCITT (Physical Education),,school,N55,10003503,
+90865ecf-95e6-4804-b656-8c5fd41f3736,North East Schools Teaching Alliance,,school,1ZA,10039055,138845
+592fa90f-042f-4968-a8b3-1877c83ae2e5,North Essex Teacher Training (NETT),,school,N46,10020534,
+69a7e148-b00b-4809-b532-3aabc852a2a4,North Lincolnshire SCITT Partnership,North Lincolnshire Council,school,N66,10004694,
+6b6456bc-c551-4ecd-8fc9-1fed1e74b379,North London New River Teaching Alliance,,school,1JV,10034567,137531
+fb91c0bb-6267-4a7f-8eff-96cd0aad7ead,North Star Community Trust,,school,6T6,10058354,
+828b2467-9e6a-464b-aa86-665202fa7260,North Tyneside SCITT,North Tyneside Council,school,N73,10004714,
+3b2c50e8-49a5-44bc-b45a-21225b05d53e,North West Learning Partnership,,school,13N,10053591,142161
+ca64486a-ec92-47a5-8c9c-e9b1e1fafea3,North West Leicestershire,,school,7F6,10055367,
+d7327fc4-fc2e-4b21-84b1-210b176d72e2,North West London Train to Teach,,school,4W6,10024318,138457
+ce037e27-4c47-4d39-9b4d-0716af368f30,North West SCITT,,school,252,10046861,
+193043d3-ddf4-456f-b850-f49d15f92eff,North West SHARES SCITT,,school,N83,10040125,
+666de1df-38fa-48e3-958d-26cf90675f83,North Wiltshire SCITT,,school,24U,10058663,
+9b4d272d-f003-483d-8328-59de33c27c22,North Worcestershire Teacher Training Hub,,school,19S,10043915,140292
+f45b469f-e9c8-47d9-8d4e-34241535a0b8,North Worcestershire Teacher Training Hub,,school,3G4,10040242,139286
+a7385db3-28c2-4f2a-8b2e-c31802fd92e9,Northampton Teacher Training Partnership,Northampton School for Boys,school,N42,10031382,
+f36d7e8c-f084-4a8e-abbf-a067a3fa10d0,Northampton Teacher Training Partnership,Northampton School for Boys,school,16G,10031382,136299
+f62a9ae7-c222-4e36-861d-19ac56dfe963,Northamptonshire Teaching School Hub,,school,1QM,10007901,135317
+8b2116a8-1b33-445a-a47e-03ef66c10dc5,Northern Lights Initial Teacher Training,,school,1YQ,10036293,137831
+a2c8d9df-02b1-4058-accc-c06d9ee76dfd,Northern Star Initial Teacher Training,,school,255,10057355,
+3c1881d6-fd4c-4dda-bcd6-62bdc7693dfb,Northumberland Teacher Training,,school,19E,10035957,137746
+d31fc422-6785-4838-98c6-1b29e456fcb2,"Northumbria Art, Craft and Design Partnership",,school,2X6,10001429,108641
+bb67077e-e4c1-4bbd-a4e6-5c0ef2aa4c1d,"Notre Dame High School, Norwich",,school,1GT,10036613,137913
+7a6cd365-8108-4d01-a6ec-1c8f7ac1115b,Nottingham Catholic Initial Teacher Training Partnership,,school,1YD,10059277,137409
+bca8a29c-79d4-44eb-b344-d8e7700b885a,Nottingham Trent University,Nottingham Trent University,hei,N91,10004797,
+98c498c1-0233-4a3c-8ebe-e81d58523fb4,Nottinghamshire TORCH SCITT,Nova Education Trust,school,254,10055362,
+8fb97228-9f56-4764-b7ac-ddc27b851c81,Nower Hill High School,,school,4N2,10034831,137028
+e63a437b-54c7-42b5-ad80-9b88d3bd2596,NWAT Futures Hub,,school,5N2,10060716,136553
+d9f145e1-716b-43d3-b4ef-709e6070e735,Oakwood Academy,,school,2CM,10037232,138130
+45d6ba3a-f32f-4ec0-b945-4b702a2e70e7,Odyssey Teaching School Hub,,school,1ZB,10032220,136353
+6537832a-0410-4222-bcf0-0a711d478ffc,One Cumbria Teaching School Hub,,school,1A3,10058240,135632
+4ee024da-b6db-4e60-b482-a012d1d5ea05,One Excellence Trust,,school,3H3,10064612,144542
+2666f6c1-a482-45f0-9b23-9a45aff2fcb8,Orange Moon Education,,school,3A7,10054833,140417
+61a69fc9-5887-43de-8b56-148357cf0ad8,Oriel ITT Partnership,,school,2LR,10016856,134042
+20f285c0-97c2-4328-9dc7-e5c93380d866,Orion Education,,school,3A2,10058616,
+2e5efa27-7654-4e1d-95a1-338bbcb9b8c5,Orleans Park Teaching Alliance,,school,2HZ,10038668,138651
+f43e79ab-8842-40d7-8d91-f857eabed2f5,Ormiston Rivers Academy,,school,4T4,10034987,137152
+0f1a1e7f-6529-4883-840a-4ea4443447cb,Orwell Teacher Training,,school,2HP,10063480,144217
+de3adc1a-f85c-403b-ab7a-277e81700fa2,OTT SCITT,River Learning Trust,school,24T,10059630,
+bca1fc54-6802-4d9e-bc88-bf7411e25967,Our Lady and St Hubert's Catholic Primary School,,school,262,10049319,141926
+8e01bdaa-f895-41bd-87b0-8f039239f869,Our Lady of the Magnificat Multi-Academy,,school,3J3,10060812,143634
+84694da5-2dfa-4fef-965e-6c1d0ab9d93b,Owls,,school,2K3,10070946,104863
+ec274057-5cee-4880-9ecd-f20abddf60c0,Oxford Brookes University,Oxford Brookes University,hei,O66,10004930,133864
+e42fefd6-82d4-4e56-80a4-9b1fd1075ce5,Oxford University,,hei,O33,10007774,
+80e1fd5f-7a76-4128-8b7c-b552be8315da,PACE Academy Trust,,school,1O1,10045671,140704
+c1fd1ff3-3c10-42ee-a4b5-db6129d2abb6,Palmerston School,,school,1AE,10016906,104748
+6665ffd7-d005-48ca-ad28-798a5b11e45a,Park View School,,school,2P1,10059154,136971
+7ed82883-fe05-4672-878f-99d921f60b6b,Parkwood Primary School,,school,2HH,10061930,143569
+f7eb3a88-cd74-4b36-a485-a494e72010b0,Parmiter's School,,school,1D5,10034176,136899
+d1818c88-bd15-4e6b-8ac8-d9f75b93736c,Partnership London SCITT (PLS),Partnership Learning,school,2B1,10053276,
+145661ce-83ed-4eae-8176-ece4e0b8aaff,Pathfinder Schools,,school,4P2,10063586,137049
+5ac276e8-0f6c-4ccf-80ea-99eaab81d005,Pathfinder Teaching School Hub,,school,1VU,10058625,136617
+e8ccd725-dddc-495e-9427-9d743029ada7,Pathways Partnership,,school,27C,10069027,107928
+58428ddd-d095-423f-bbca-a1577d035325,Pele Trust Partnership,,school,16S,10082400,145780
+41582cce-3b15-41f4-9112-4eff3aa6052a,Perins Innov-8,,school,2DC,10034823,137128
+947b43ed-f6cb-459d-a807-99d73b7aede4,Peter Pan Training Partnership,,school,2AF,10089196,
+1049a36c-9577-4de7-97f7-f9b9add029c7,Pioneers Partnership SCITT,Great Academies Education Trust,school,1Z8,10058215,
+92021060-5e05-416c-bbcb-13cfc78e459d,Pioneers Partnership SCITT (Primary),,school,2Z8,10058215,143319
+c43cdc5a-21b7-49ef-a0db-8f2ff0dc3a9b,Plume Community Teaching Partnership,,school,1XB,10035963,137790
+566f604b-4ed5-46c5-8e86-c6505b23da49,Plymouth Marjon University,University of St Mark and St John,hei,P63,10037449,
+ff35c705-3f47-4559-8db8-1ff6c8403aee,Plymouth Teachers and Schools Alliance,,school,1T7,10037449,70131
+99ef6a45-a384-465c-8017-f4d3263fde56,Polaris,,school,2GW,10080313,121653
+c3cdb46b-fa73-4826-aea6-dd4ae12d79b5,Poole SCITT,TEACH Poole,school,P75,10057353,
+2ed1170b-ee44-4332-9f42-639579804943,Portsmouth Primary SCITT,University of Chichester Academy Trust,school,P82,10042780,
+cc45b761-22a0-4dce-aba5-075bf65e1795,Potentia Teaching School Hub,,school,5P2,10007851,113033
+43d80a06-8401-4ec7-8431-13120d4e8f7d,Potteries Educational Trust Teacher Training,,school,4P5,10066111,
+439a8494-8ec1-4b32-87d7-7053c9deb5ff,Prestolee SCITT,Prestolee Multi Academy Trust,school,2AS,10055218,
+16017cd9-2d86-49f6-aef1-8f436a885ea2,Priestley Partnership,,school,7G7,10064304,143566
+3f431fe0-4a93-4ba0-96c7-b303cbece9b1,Primary Advantage,,school,1XW,10079309,100263
+d1b21724-c07d-4003-9c6f-1cd7ef40a47d,Primary Catholic Partnership SCITT (PCP SCITT),,school,P85,10045987,
+ef38bce5-59d3-49e0-bd2f-fcc4433d3104,Prince Henry’s and South Worcestershire ITT,,school,2ET,10032987,
+266bc62b-662b-472d-b42b-ecef9fc3c21c,"Queen Elizabeth's Grammar School, Horncastle",,school,2KK,10038619,138665
+49cb4983-739d-4ecb-bfaa-28c4080d7030,REAch Teach Primary Partnership,REAch2 Academy Trust,school,1QU,10060390,100706
+43e34c0c-83a6-4d3d-ad19-04e6a5c0311e,Reach Teacher Training,,school,7K1,10037673,138266
+1199902a-0726-4db6-854e-4e132e790cc1,Red Kite Teacher Training,Red Kite Learning Trust,school,2B9,10054307,
+98d01dbb-be90-4707-b673-8cfe90153245,Redborne Upper School And Community College,,school,1R7,10033274,136559
+852e50ea-7162-41d6-9410-b82f5ad48268,Redcar and Cleveland Teacher Training Partnership,,school,R16,10005413,
+69031f4b-e289-468f-b742-00e6e761d38c,Redcar and Cleveland Teacher Training Partnership,,school,3L3,10084206,147393
+9673ce13-5616-41e3-8d0d-148b0d808e4f,Redriff Primary School,,school,1U2,10034551,137648
+01033e2f-151a-4f09-91d4-bf28ff7df77b,Redwell Primary School,,school,5J7,10074797,148611
+ad82c6c0-5622-4514-90a9-592294d9fb15,Richard Hale School/The Sele School Partnership,,school,1N6,10042280,139873
+f76cab0c-b198-4a02-a4d4-ab182f009b5f,Richmond School,,school,18L,10065396,145090
+ece25c5c-92a0-4df6-bec1-78e93040e904,Ridgeway Education Trust (RET) SCITT,,school,4R2,10059844,138490
+ce94fce7-322d-42a0-8504-1579c48bbee3,Riding Forward Education Alliance,,school,1PU,10073374,117889
+085c5e7e-3259-4f9e-84f5-f21699bcec0b,Ripley ITT,The Bay Learning Trust,school,R23,10058677,
+ad746d71-0261-4ec3-8bbb-28c931c1b08c,Rise Multi Academy Trust,,school,4R1,10059914,140850
+a3a1da0f-d465-43d6-b34c-109e80163a71,Risley Avenue Primary School,,school,29Y,10076690,131879
+864f8d73-d34b-4745-8a2e-98c8a0ba57ed,Rivers Teaching Alliance,,school,2B7,10007139,141443
+614bcbfc-38f7-464a-8f25-1b210dd21f0c,Riverview Institute for Teacher Education (RITE),,school,2Z2,10000580,118109
+34f87e32-f3c2-4a2f-9cac-994ba7f6bb64,Rowan Gate Primary School,,school,4G4,10075272,131079
+fc4b0d07-b515-464a-b32e-65d2639e4c83,Royal Greenwich Hub,,school,1G2,10078039,100158
+1fff8aed-14fb-4e1a-933e-ddc48d43ce34,Ryders Hayes,,school,4T5,10033094,
+153720e3-994f-4976-a9c2-26086cda3760,Sacred Heart Newcastle SCITT,Bishop Bewick Catholic Education Trust,school,2BA,10059424,
+186e40d0-48dd-4865-9687-3e2993040b64,Sacred Heart Secondary - Redcar and Cleveland Teacher Training,,school,5H1,10053885,142273
+cc8ceb38-51f3-48d7-b337-97dcde7412e7,Saffron Teaching School Hub,,school,5A7,10033783,136776
+23be0e4f-3b18-4e04-ae48-8b72848caef7,Saint George's Church of England School,,school,295,10052832,70055
+f76ca646-d009-4936-a565-0ef267dd5e4e,Saint John Southworth Enterprise and Research Alliance,,school,15O,10049304,141931
+e2d6a6ca-5cb7-4944-abfa-675e8db9a41b,Salford Alliance of Learning Schools,,school,2F8,10077015,105910
+664da565-9c49-453e-8ac4-7f54bbe1b43a,Salop Teaching Partnership,,school,1Q6,10059785,138216
+226fa322-1c2d-49d5-b35e-373e37f69599,Saltaire Primary Teacher Training,,school,2X8,10078397,107270
+fe06397b-9c3e-477e-9094-54207afb44e6,Samuel Pepys School,,school,1CB,10017555,110951
+60e416e0-7044-4cb7-ba74-0e3ee2989c18,Scarborough Teaching Alliance,Coast and Vale Learning Trust,school,1YS,10007149,121267
+57c9ad73-42bf-428f-ba74-1614d5fca89e,Scarborough TSA - Coast & Vale Learning Trust,,school,ST8,10007149,143288
+bb62160c-ab45-4534-864a-2d7001530f7c,SCITT in East London Schools (SCITTELS),Colegrave Primary School,school,S17,10046003,
+e26eeb16-19e4-4271-889f-965f1fb96244,SD at Turton,,school,2BS,10003957,105253
+15402d96-5561-439b-b012-e6530e21503b,SeleFirst@NorthEast Partners,,school,16B,10078829,122242
+acabd586-bcd2-4c90-813c-f876423ee7f6,Services for Education,,school,1WE,10046628,
+1dc2c920-f059-4526-a1b5-7733ffa5cf6d,Severn Training and Schools Alliance,,school,1B5,10016969,123635
+fca2eb7a-f566-4504-abe9-d13e941a9d30,Sharing Excellence Partnership Dunraven School Streatham,,school,1BW,10034534,137093
+83bc1339-5332-45a7-8c2d-ccfa849169b7,Sheffield Hallam University,Sheffield Hallam University,hei,S21,10005790,133871
+753b0bdc-4ae5-4943-bf91-ffd934d1b18b,Shepway Teacher Training,,school,1NG,10073318,118505
+aefa0213-4abb-41dd-ad9d-af97f2fef900,Sherborne Area Schools Trust,,school,18M,10059883,138471
+d2a56a20-5585-4ca4-9a88-d3f19ca88035,Sheringham Community Primary School Partnership,,school,1A5,10072540,120851
+96d82a55-6c2a-4123-bc71-c8e632e723be,Sheringham High School,,school,8H6,10004772,70287
+b1a45e5a-a490-4673-8342-728a22d3e8f8,Shires Teaching Alliance,,school,2EB,10058699,136786
+729b506a-8db0-4d12-bd1d-fd254b08246f,Shropshire Primary Partnership,,school,2AN,10007848,145790
+ad71d797-c895-4628-8f61-d012ff57a859,Slough ITE Partnership,,school,7D6,10033213,136521
+c57ae73f-c588-48dc-931f-95bb5ec0ea2b,Somerset SCITT - Oak Partnership,,school,5S2,10005959,70066
+45540140-6578-424d-af2c-28a91e547e81,Somerset SCITT Consortium,,school,S31,10005959,
+9ec82079-b151-46a5-bef0-33f22280f68e,South Birmingham SCITT,Summit Learning Trust,school,19O,10052836,136406
+f239e0fc-e509-47de-9fab-2712b17255dc,South Birmingham SCITT,Summit Learning Trust,school,N32,10058342,
+cbb07369-6204-4d33-b996-086725b3810c,South Cumbria ITT,,school,2KS,10058677,135940
+ba4e841c-0a3e-4d48-af35-d2bb451b073f,South Downs Teacher Training,,school,2AZ,10045651,
+61f8fb58-f065-4757-939d-f72530d511a1,South East Essex Academy Trust,,school,2W2,10058517,136490
+f0528a0c-135b-42ba-9b80-c98831147204,South East Learning Alliance,,school,1J1,10037408,138178
+61cfa7de-e83d-41a4-9108-36f7ff80de18,South of Tyne Primary Alliance,,school,2JZ,10007159,144220
+7e3015c4-cd07-4d55-924c-a9e3352af9c5,South West Teacher Training,,school,7M7,10060466,
+325ee5b9-239f-4bef-a46c-96780ccc199d,Southam Teaching Alliance,,school,2BN,10062422,143905
+3036405d-f1f4-4ffb-a792-bcd207e90c9d,Southend Initial Teacher Training,,school,1AV,10035498,137515
+0e8c4af2-cb26-4555-aea6-7158e64b0ab5,Sparkenhoe Lead Partner Leicester,,school,1RL,10082990,146857
+2ad4275f-f9da-428d-8dd2-772278f63425,Sponne School,,school,1PJ,10033021,136488
+6f1da8b6-a483-4756-bf6d-61a519d581dd,Springboard,,school,2HX,10003861,131570
+1015b118-4764-42e8-b595-8e976cad1865,Springwood High School,,school,1U4,10033204,136515
+ced3fbb8-e9ec-47d4-b1a7-eeaabea79efc,St Andrew's Alliance,,school,2C7,10068553,105933
+ca90866e-3dc9-4ca7-a31a-268bfdf4f81b,St Andrews CE Primary School,,school,1VA,10074731,100613
+731b1003-9d8f-48b3-943e-7b2673ee4010,St Angela's Teacher Training Centre,,school,1XC,10006109,102786
+eb90229a-a151-41f2-8ad6-bd4ffbdca9eb,St Anthony's Primary Learning Partnership,,school,1Y9,10078651,108021
+859171b4-e0c0-43b4-9a12-8b45b8dadf7b,St Barnabas Multi Academy Trust,,school,5B7,10060585,
+00ef290d-2479-446d-a3ab-465640f56902,"St Bede's Catholic Comprehensive School and Sixth Form College, Lanchester",,school,1QB,10037433,138172
+a21c8ed6-a7e3-40d9-980f-78ea74a38b1e,St Bernard's,,school,29P,10037583,138329
+2e0a933e-7214-47d5-a006-f470c39b87b3,St Edmund's Nursery School & Children's Centre,,school,1EN,10047807,107190
+62611bb8-7168-446c-8121-c068b8ecbf00,St Francis & St Clare Catholic MAC,,school,5F3,10048946,141802
+91065662-87f4-497a-8514-d30b6e682c78,St George RC School,,school,1NK,10040659,139369
+7c64bc60-7299-43e9-836c-0c23676eb687,St Helens ONE - Grange Valley Primary,,school,2KF,10073116,104774
+5051471b-27f6-4549-9ef5-246295c2bf3d,St Ives Primary School,,school,2BL,10054993,142505
+cbc12200-1dde-4dfe-ba63-3974be9be9fe,St John Bosco Catholic Academy,,school,5L9,10060532,
+f34e36a6-bcc2-49c4-9d81-e98534ee1de2,St John Bosco ITT,,school,1S9,10079439,103991
+6622f22f-d396-465d-9394-2d8a1d96d433,St John Paul II Multi Academy Company,,school,8T8,10000722,103560
+c9f194a8-af6c-4666-bed1-11e17fe4c231,"St John's Church of England First School, Wimborne",,school,225,10048991,113771
+70768496-ec3e-46a1-999b-f29f3ab53bfa,St John's School and Sixth Form College,,school,1W4,10035670,137702
+865cce0f-8b6c-4749-ae96-f9c9acb876dc,St Joseph Catholic Multi Academy Trust,,school,5S7,10090107,
+e2974558-a4c2-414d-a57b-a4727770caa1,St Joseph's College SCITT,,school,1WJ,10032965,
+d52140c5-b0cf-4f44-a1ec-d9d8ddd4f966,St Joseph's College SCITT (School Direct),,school,1O2,10032965,136460
+553667cf-541b-44b5-9c30-06439265540d,St Mary and St Thomas Aquinas Primary School,,school,2T1,10090323,149052
+aa361c2b-c645-48d0-b3b2-6d619781003e,St Mary's Bryanston Square,,school,20000,10073999,101136
+7bbd9238-1e16-4166-955b-0bbcf582cf02,St Mary's Catholic School,,school,2KN,10043057,140081
+88c41981-3e1b-405b-869d-d3f697e7e686,St Mary's CofE Primary,,school,3S2,10071424,102139
+33386c7d-25b2-461b-a4d3-92de44ae8c95,"St Mary's University, Twickenham",,hei,S64,10007843,133895
+28547144-19de-41bc-9141-ec9f0715c05f,St Marylebone Collaborative,,school,1ET,10035059,137353
+1174c0cd-6173-4a50-ba10-d8f64477663d,St Michael's CE School Rowley Regis,,school,3M3,10017787,104019
+6b9bb933-d977-463e-a20c-8e9b11910965,St Paul's Caritas Christi,,school,242,10006246,103531
+bec7a2c0-4099-4cd7-9e09-6efd978a0712,St Peter's London Docks CofE Primary School,,school,1V1,10074014,100960
+9f9d8d91-7724-4489-be32-3e55c410e55c,St Peter's Solihull Teaching School Alliance,,school,17Y,10086770,104119
+a5811940-58e2-406e-bd6d-c615423dd0b4,St Polycarp's Teacher Training,,school,2EG,10084196,147429
+da3f9aba-ef22-44e7-97d0-cfebb09697b4,St Thomas Catholic Academies Trust,,school,3G3,10060998,143803
+f2660b4b-b625-4dc4-b3ee-9e25981ab0c5,St Thomas More Catholic School,,school,1OO,10036413,137851
+401c846c-3c76-4e38-9ada-043bdf7e12fe,St. Andrew's Teaching Alliance,,school,2DD,10074236,123126
+d6563986-1801-43d9-92bf-8dd9f1b7c183,St. Edward’s Teacher Training Partnership,,school,1EG,10079503,147335
+76ad9408-5fd0-4078-aca4-392b2c038f09,St. George's Academy Partnership,,school,G15,10029212,
+01a63fa2-81a2-49f4-ba1e-45590fabff83,Stepney All Saints Partnership,,school,132,10005863,100977
+652e041d-fe6a-4511-b534-a4d6ff9fb1f6,Stevenage Schools' Partnership,,school,2C8,10006765,117530
+e7c06547-84fa-4f97-9a75-3e32cae7e236,Stockton SCITT,,school,S60,10006337,
+8ae93c0a-bc4c-4cbe-b0be-c137f241913e,"Stour Vale: Teacher Training Hub for the Black Country, South Staffs and Shropshire",,school,1FA,10059465,139872
+a2947adf-41a9-4d18-a289-81294577ea27,Stourport SCITT,Severn Academies Educational Trust,school,S95,10058732,
+8acf7500-7614-4c58-990d-84a9f646c57e,Strive4 Academy Trust,,school,6S2,10066119,
+9672daf1-1630-4412-9ef1-1420191169d6,Suffolk and Norfolk Primary SCITT,,school,S13,10006399,
+bace207b-b412-4a8a-b4f1-89a5e9667848,Sunderland Aim High Alliance,,school,1A7,10044819,140584
+8f96e14a-5990-4912-80eb-95c9ed4d6804,Sunderland Nursery Schools,,school,2JQ,24246977,108753
+3e5c78aa-a354-4c84-a9a8-c9915f6d5964,Sunningdale School,,school,23M,10018663,108882
+10d29f95-7c7d-47a9-ba5a-74a2d2eaa780,SUPA Salisbury,,school,1FZ,10007158,133879
+ab60bbb3-1c07-4e50-ae8c-07c56bc74ad7,Surrey Downs Partnership,,school,3F4,10000399,125264
+78ba5691-d1b9-485b-9915-b204035d3cb7,Surrey Downs Partnership with the University of Sussex,,school,3F2,10000399,125264
+0928dc0c-fb28-4b90-b223-2e4cf4ddc997,Surrey South Farnham SCITT,,school,13S,10054050,
+e9ed4f88-75ee-4073-aedc-6edf12d553e0,Sussex Teacher Training,,school,4S6,10035578,145440
+5f09ca9d-7e6c-4072-847f-828d26ca6f97,Sutton SCITT,The Willow Learning Trust (MAT),school,1ZW,10058739,
+1d3ad347-ed10-4ce3-b90e-9f82b60cc8fa,Swale Academies Trust,,school,14H,10031371,136286
+d0f9dc16-e122-4465-a0ad-68dbcd678c7b,Swale Academies Trust with the University of Sussex,,school,3S6,10031371,136286
+609b3d97-2613-4207-82a9-158de70750d3,SWIFT Teacher Training,Education South West,school,3S3,10058417,
+af9984ee-2922-4783-8790-43424bc605b6,Swindon Teacher Training Partnership,,school,2KD,10034861,137264
+a8ffbc17-938d-4948-a11d-5ffd65795d1e,Sydney Russell Teacher Training Centre,,school,1EJ,10048673,141683
+7b6e6d27-dfac-4721-969a-3575cdf2ee01,Tall Oaks Academy Trust,,school,27M,10052488,140329
+9bb55c4a-a357-4976-9fa6-a693f84e4a1c,Tanbridge Teacher Training,,school,3K3,10017297,126064
+fc81b2db-66c3-4607-bc02-a0bb84082e6f,TCAT Train to Teach,,school,2H4,10064284,16682
+fdb85e54-588d-4bd5-aa1a-4c3302030543,"Teach Central, formerly RSA Academies'",,school,26A,10038446,138505
+7ada4e9b-d97c-4d56-89a4-2efddc98bf3c,Teach Cheshire,,school,1JS,10031375,136278
+78f7299e-b0f8-4236-b37f-a777b6c9f651,Teach East,,school,T11,10058314,
+09862025-3fe7-4134-b6a4-9ec7b4cffe5d,Teach First,Teach First,other,1TF,10024318,
+e40e4f43-2edb-42b5-a3ff-784181c8d181,Teach for Life with LiFE MAT & Partners,,school,1A4,10036928,137969
+d305b798-f024-4235-9404-c6c7ecbfcf43,Teach Heart Alliance,,school,1D8,10074951,105243
+f76419d0-3b19-49b0-880f-0041ccab19cd,Teach in Kent,,school,26J,10066627,145440
+ad2ed515-7282-4448-a24e-7510ea3b2108,Teach Kent & Sussex,,school,2EZ,10058549,
+ab81b205-fa17-4af3-8b24-4cfc696cb860,Teach London South East,,school,2GP,10035578,70275
+43bc49b9-2323-480f-8bd4-4a6617496739,Teach Maidenhead,,school,286,10035798,137740
+c29fa6ee-0275-4d71-b9c2-120e214b2012,Teach Manchester,,school,1HJ,10017302,131880
+9ff1c658-818d-4cc9-b136-5dd3408f65ef,Teach North East,,school,1D7,10063921,144204
+9756c58b-98a3-46c1-9219-135a3e2774d2,Teach Thurrock Primary Partnership,,school,166,10039702,139104
+d4e2cda5-6ae4-405c-89a8-b47adeaf502b,Teach West London Teaching School Hub,Twyford CofE Academies Trust,school,1KV,10035500,101933
+68f959cc-394c-45c5-8506-57f6391acc98,Teach Wimbledon,,school,1ZO,10007190,102683
+24414c14-24c5-4750-9f86-fefdc88b9bd9,Teaching London: LDBS SCITT,"Christ Church Primary School, Hampstead",school,1VM,10074742,100028
+a2b39915-b041-4bd8-9ede-cfc62664ce56,Teaching London: LDBS SCITT,"Christ Church Primary School, Hampstead",school,L59,10074742,
+de8eacaa-5509-4279-ac3b-0824e667e49d,TeachSlough,,school,17T,10032611,136420
+0c71a204-d550-4643-8d34-e917e0604d8f,TeachWestLondonPGTA@St Mary’s,,school,S65,10007843,
+af4ceacb-9988-4e95-a9ca-9e2d5b05e515,TEC Partnership,,school,8T2,10007938,
+9f3b2810-b333-4f43-974b-7e95fc61e759,Ted Wragg Teacher Training Partnership,Ted Wragg Multi Academy Trust,school,S66,10060466,
+18681d7e-35f7-47fa-ae8d-3acaa31b7380,Teesside University,Teesside University,hei,3S1,10007161,
+fc032a8b-88a8-4b10-a77d-a6adc84753c9,Telford Partnership,,school,2GO,10007166,142705
+25320b7c-5695-4a79-a978-a049749e8313,Tes Institute,Tes Institute Limited,school,H40,10035578,
+94087447-d972-475f-9963-ce35e64a50da,Thames Gateway Teaching School Hub,,school,1FN,10033431,136662
+d26c763f-1538-40e9-b7c8-5fd6dc8d5475,Thamesmead SCITT,,school,T26,10034809,
+7c1ecb8b-07e9-4ffe-8a47-be635a47d357,The Bardney Church Of England And Methodist Primary School,,school,1N2,10078117,120589
+02e0f2c0-f5f0-47b3-ae8e-9e5c3f50cfa9,The Basingstoke Alliance SCITT,,school,B17,10034865,
+e01e5a0e-887a-4d97-8262-61ddc7988189,The Bedfordshire Schools Training Partnership,,school,B31,10055198,136713
+a60cabd9-a054-493e-99b5-1ebc16430ad0,The Bishop Fraser Trust Bolton & Bury ITT Partnership,,school,18J,10064724,144046
+92156828-ea8b-478f-af6b-21a60a3e146c,The Borromeo Training Hub,,school,4B3,10006135,130411
+1bdc6cd6-fa30-46d6-98ad-e5263cc25e11,The Bracknell Forest Partnership,,school,2FZ,10034787,137267
+4a873251-7f96-476c-9edb-c2ad976f5f3a,The Bridge London TSA,,school,1W6,10057627,143217
+71390545-edc4-4ca8-a914-2fcdfeedd522,The Buckingham Partnership (School Direct),,school,258,10035071,137344
+4526a23c-4845-4f7e-8206-3f96e22cc52f,The Bucks Hub Partnership,,school,2FX,10034632,137219
+79477963-8661-4022-971e-e36e2ab97f71,The Cambridge Partnership,Meridian Trust,school,C03,10053421,
+2caa4da8-1d73-4c2d-bbd0-3f38607cfa4d,"The Cambridge Training School Network Partnership, CTSN",,school,1LK,10032979,136463
+7256675b-4f57-4dd4-9a35-fe643782286d,The Coventry SCITT,Sidney Stringer Multi Academy Trust,school,2A7,10058243,
+11cc0c27-b6c5-42b1-b782-e18271fa4bf8,The de Ferrers Trust,,school,100,10032605,136414
+03a9c170-2960-4212-80b2-75e21d8ce866,The Deepings SCITT,,school,C36,10058447,
+21480019-f042-4dc1-b4fa-c96c3ab9a136,The Diocese of Hereford Multi Academy Trust,,school,2D3,10060662,
+5f0953ff-2224-463f-af47-50a02b794732,The Education Learning Trust,,school,1OJ,10047166,141275
+22063d48-3373-4cb2-9dce-5e31a8b7e077,The Elliot Foundation,,school,5000,10059861,
+3b2d7ff9-2366-482d-b160-b0754a3a39da,The Federation of St. Elphege’s Catholic Schools,,school,149,10078365,102997
+52984acb-daef-4738-86d1-abee625e3a7d,The Ferrers School,,school,3F3,10042617,139988
+e151ce7e-ebd9-402d-8727-fba9e27e75ca,The Golden Thread Teaching School Hub,,school,155,10038662,138729
+774baa56-061b-4556-91b5-64a464635c91,The Grand Union Training Partnership,The Grand Union Training Partnership,school,G60,10058513,
+e2b155bd-fa62-45f9-b64b-8e792b278fe3,The Griffin Schools Trust,,school,3G5,10059492,
+0fce1532-07c4-449c-b79f-901e96b3b722,The Griffin Schools Trust Teacher Training,,school,2LF,10059492,103067
+2b36402c-839c-40ed-b2cb-871e423f55ca,The Harmony Trust,,school,3H7,10060711,
+5371cfef-11fc-452a-aa4d-7a3892593677,The Havering Teacher Training Partnership,,school,H17,10059123,
+c2ea5cdb-b76d-4d67-b41a-c659b60996cd,The Heath Consortium,,school,1DO,10003957,136779
+840ad132-5285-4a93-a9b7-806d4f9b1617,The Holy Cross School,,school,1MO,10038104,138459
+87c047d6-6edb-406c-a3df-f7fe2be7f9d0,"The Ignite federation, (The Revel Primary School)",,school,5L5,10080487,130878
+c351de63-e510-4c78-bf72-29ff98ac506d,The John Taylor SCITT,The John Taylor MAT,school,24V,10057362,
+d82baa12-d537-4ad8-9ebb-a9e2c8250ed3,The Joseph Whitaker School,,school,2K7,10035689,137628
+a4fee03e-c0e8-4972-8614-f09ca5866783,The Kite Academy Trust,,school,7V4,10061033,
+6f085d5f-f51a-40a1-bb0c-3cbbe28bcb29,The Leaf Trust,,school,27R,10092939,149948
+c0988dbe-3546-4d89-b271-d6a1cb46b078,The Learning Institute South West,,school,L19,10057945,
+3c20ab11-fdcf-412a-a01a-5800bf77a01a,The Learning Partnership,,school,1M1,10036828,138002
+5d172969-8f9b-4cf8-8ee2-5654c4a74510,The Legacy Learning Trust,,school,1SP,10007733,140722
+9468c653-c8e0-433a-aa1a-9e19751e2948,The Leigh Academy,,school,24Q,10052832,135964
+fe437883-7646-4d91-915c-60a047f962be,The Lion Alliance,,school,1K1,10034651,136963
+82dde4fc-6acf-4983-8dac-a586435eea6d,The Lozells School Direct Programme,,school,139,10015923,103509
+5ece9bd9-e720-4271-b7ba-f1611abd6d82,The Millais Alliance,,school,1BK,10016537,126066
+5999c413-4229-4c6d-996a-a5522e6c6355,The Millais Alliance with the University of Sussex,,school,3M1,10016537,126066
+e46902fe-7d0f-4be0-a309-7d5fc027fed2,The Minster Learning Alliance,,school,1EC,10081959,145643
+5977aa5e-d801-4576-a18f-3ac541061cfa,The National Mathematics and Physics SCITT,,school,2H8,10058686,
+70cd578d-816b-403f-a810-43808306469f,The National Modern Languages SCITT,Chorus Education Trust,school,2F1,10060171,
+47962bd2-9076-47f4-833c-ec20cac4dbfa,The Olympus Academy Trust,,school,25X,10036157,137753
+97760383-5e52-4871-b16d-a373472c392b,The Primary First Trust,,school,3N3,10060641,
+916b3d36-6733-4504-aa96-78bb07f4da45,The Priory Learning Trust,,school,2000,10034815,137300
+c7636dcc-b509-49b2-b53b-8265f6d27d03,The Pyramid Schools Trust,,school,3P2,10058888,
+7c668900-ed6d-466e-83b5-8ef7e65e909a,The Ripley Academy,,school,2T8,10047141,141259
+4bc78718-05f5-4a4e-b36b-40dc7a47d965,The Roseland Academy,,school,4B2,10033262,136572
+ab5f1245-2124-420f-8a4d-312bf4a7f810,The Royal Borough of Windsor and Maidenhead SCITT,,school,1WM,10005550,
+d36636d8-d3cc-4dac-9fe1-b1c6385ef261,The Rural Schools Alliance,,school,2EN,10017713,116424
+e0e7490c-a8fe-4bae-8e9d-2f58bedc1ee3,The Rutland and District School Federation,,school,1F1,10033296,136530
+97457183-c811-4097-a922-0f568ce29871,The Rutland Learning Trust,,school,3N6,10047605,141454
+e89b91fc-0e0a-4325-84fc-c7ea6486c83b,The Sandstone Trust,,school,26L,10003957,138483
+181031f6-ccbe-46f1-b9d2-7c7e6442ae15,The Sheffield SCITT,Notre Dame High School,school,S97,10037587,
+825c7de7-3d1a-4969-8df8-264a2fe9b820,The Shire Foundation,,school,S25,10046141,109578
+6f72b5b9-7b7b-49f8-9284-785d78ea348e,The Tommy Flowers SCITT,The Denbigh Alliance,school,1YK,10006289,
+b5cb24bb-e48b-4f51-86ae-3c486815d732,The Viridis Schools Partnership,,school,2CN,10078029,100234
+64bfa139-2030-4f98-a0a4-e8e2596ff77e,The West Bridgford School,,school,219,10033343,136628
+9e58fd01-875a-452b-90c0-8afab745765e,The Wokingham Federation,,school,152,10034161,136891
+167e22c2-2256-491a-ad4d-6b7c49637510,The Wonder Institute of Education,,school,2HT,10062312,143588
+1c62c4a4-c3fa-45dd-b985-7a83d4668ce5,The Yorkshire Rose Teaching Partnership,,school,13R,10035145,137424
+9136f58a-ddaa-408c-a686-b962e7d244ec,Thinking Horizons (TSAT),,school,1DX,10032200,136313
+35417b78-df14-4885-8879-01b5561f9ddd,Thorndown Primary School,,school,2LV,10072300,136814
+6b9c94e3-ea97-461c-b3be-610e64557512,Three Spires Trust,,school,6T2,10088355,141486
+6aaf1575-004a-48d6-ac05-ed8a126220d8,Thurston Community College,,school,2TC,10006910,124802
+9309dc06-e5fe-4601-a9b4-bc76295bf952,Titan Teacher Training,,school,T30,10039377,
+5f7da10b-579e-4917-a090-c4fc42f1757e,Tividale Community Primary School,,school,142,10073602,133261
+0fd4e7a1-2911-4b77-90bb-bac5ffe31972,TKAT (School Direct),,school,2G5,10005374,136456
+be27f198-ea17-4289-a40e-cf4d00f5eb2e,TKAT SCITT,The Kemnal Academies Trust,school,K13,10058343,
+bcbbe70d-819f-4d03-a6d1-27a0e8539d47,Toot Hill School (Nottinghamshire Torch SCITT),,school,1EB,10055362,136878
+295cf8aa-b14a-4342-8aaa-71a067204d1d,Torfield School,,school,1YE,10047137,141476
+ba7f7c3f-dc00-4a3d-a411-da5393b10774,Transforming Lives Educational Trust Initial Teacher Training (TLET ITT),,school,1XO,10044162,140372
+6c59bd9d-949d-42be-bf29-1144a0eaa318,TSAT SCITT,,school,1SF,10024318,138069
+0a5a6876-dc9b-43a3-9bba-f3a938e163ad,TTTC (Thurrock Teacher Training Company),,school,1CN,10016633,115356
+f2451d52-66a1-4d8f-8861-eb85bbefce41,Tudor Grange Initial Teacher Training,,school,T87,10031583,136310
+ba9d2902-caf7-4726-83c8-a09ed97597bc,Two Counties,,school,26Q,10006865,110048
+63fb6b37-5579-428a-baeb-bd0033e97fbf,Two Mile Ash ITT Partnership,,school,T89,10059102,
+9e1aa73e-16e1-4f22-bad6-135cca91a640,Two Mile Ash School,,school,1WY,10059102,137061
+37f7b0aa-255c-4cc2-ae3a-81c49ee0ba32,"UCL, University College London",,hei,U80,10007784,
+5ee3cc4d-7312-41ec-a116-becf1cb25a6c,United Teaching National SCITT,United Learning Trust,school,1A9,10037395,130912
+735d08d2-3775-46c2-a4ee-9b9b5bd1b768,Unity Teacher Training Partnership,,school,3U1,10072593,107275
+c9b87cb9-ddde-4d1c-a2d5-5d288e1f175a,University Campus Oldham,,hei,KG8,10006770,
+3f13d9bb-9d1b-453b-94b8-5dd65b37a3f5,University Centre Farnborough,Farnborough College of Technology,school,2F3,10002412,
+5635c667-c77c-436f-89e3-d7fff69be98e,University College Birmingham,,hei,B35,10000712,
+8ffa8efe-8a1d-4778-89ad-d156fb5c7412,University of Bedfordshire,University of Bedfordshire,hei,B22,10007152,
+e0cdf62e-63cf-4bb2-984b-2baf7b959b85,University of Birmingham,University of Birmingham,hei,B32,10006840,133784
+7f23e4cc-90c1-42ef-adb4-628046f630c8,University of Bolton,,hei,8N5,10006841,133794
+f59e5bfb-cdc9-4116-9e3b-d3946c45447c,University of Brighton,University of Brighton,hei,B72,10000886,133796
+88c4f7de-b91e-4870-95ef-c33ac58248b3,University of Bristol,University of Bristol,hei,B78,10007786,
+c5b60c72-7683-4617-90c7-16cd8ae58373,University of Buckingham,University of Buckingham,hei,2Z3,10007787,
+81d66f47-0ca8-465c-bbfb-2146cf42bcb6,University of Cambridge,University of Cambridge,hei,C05,10007788,
+e214f0ef-1134-4f17-9c81-30ce08ae2a67,University of Chester,University of Chester,hei,C55,10007848,
+481c16da-7bab-44d4-86d0-72f06994f29a,University of Chichester,University of Chichester,hei,C58,10007137,133868
+c27d29dd-0844-48ed-b90b-c7bfd6f82c9d,University of Cumbria,,hei,C99,10007842,
+1dbcbd9d-bc52-4feb-9698-612e7d007b1d,University of Derby,University of Derby,hei,D39,10007851,133811
+254ceea3-0d98-461a-bef1-da38678aeb34,University of East Anglia,,hei,E14,10007789,133853
+5a98ba39-20bc-46d8-aca7-d025048e5ae9,University of East London,University of East London,hei,E28,10007144,
+c9262dcb-b07b-41e1-ada4-4064ef99ae73,University of Exeter,University of Exeter,hei,E84,10007792,
+4168351f-0485-46e8-ae84-83456cfb1956,University of Gloucestershire,University of Gloucestershire,hei,G50,10007145,
+fefe9baa-a457-4da3-85f2-f3c8e943ef4f,University of Greenwich,,hei,G70,10007146,
+75ed8fb6-18f3-4798-a9c9-a2405c8745ce,University of Hertfordshire,University of Hertfordshire,hei,H36,10007147,133783
+f08c2672-6c57-4282-8ecd-9e9bf2dac887,University of Huddersfield,University of Huddersfield,hei,H60,10007148,133822
+3cdb23bc-3893-426f-901e-9ced91047a7b,University of Hull,,hei,H72,10007149,
+767fb786-2eee-44d9-95ec-b63cabacf1f3,University of Leicester,University of Leicester,hei,L34,10007796,
+7ef7e682-9222-40ce-a368-586d8ac15923,University of Manchester,University of Manchester,hei,M20,10007798,
+ddf4d7ef-201d-491b-9642-eed8ea6c67db,University of Northampton,University of Northampton,hei,N38,10007138,
+45424588-d397-4d90-9d03-3aad48339a8d,University of Northumbria,University of Northumbria at Newcastle,hei,N77,10001282,
+24afc904-858f-415f-ae54-40c9b6f437ad,University of Nottingham,University of Nottingham,hei,N84,10007154,
+cbcf4227-3812-4559-aea8-9bdd128582e5,University of Plymouth,,hei,P60,10007801,133865
+835a3030-788c-4b71-b2c4-6f3988d7801a,University of Portsmouth,University of Portsmouth,hei,P80,10007155,
+c778acab-bc69-4775-9df4-14579ab21d7c,University of Reading,The University of Reading,hei,R12,10007802,
+7dd1206a-6393-4bde-972c-22fec0447552,University of Roehampton,Roehampton University,hei,R48,10007776,
+d95fee67-3da7-4245-b45c-83ce8a2a38f3,University of Sheffield,,hei,S18,10007157,
+8b95faa4-6f77-4aab-a7ec-c6ea4a0d04c1,University of Southampton,University of Southampton,hei,S27,10007158,133879
+02ff5d0b-b219-4c20-ab6b-58b7ff282e70,University of Staffordshire,,hei,S72,10006299,
+f181a9c7-8e03-4960-804e-6bfdf70c656d,University of Sunderland,University of Sunderland,hei,S84,10007159,133881
+f2130f76-c254-487a-8e62-80436be906be,University of Sussex,,hei,S90,10007806,
+57ed7498-284a-4032-83df-09c2a5da8c70,"University of the West of England, Bristol",,hei,B80,10007164,133798
+5ce8b711-3848-4524-a4d5-c15a839a10c5,University of Warwick,,hei,W20,10007163,
+294e772d-f880-4dc0-9bef-8942673b125e,University of Winchester,University of Winchester,hei,W76,10003614,133880
+1984094a-0583-4f2e-ada0-7a5a5fa4f7f4,University of Wolverhampton,University of Wolverhampton,hei,W75,10007166,
+bd50f394-bb44-4960-9994-147c8cf13779,University of Worcester,University of Worcester,hei,W80,10007139,133911
+7b0416ea-797d-4f1e-9255-e9950fe98bd5,University of York,University of York,hei,Y50,10007167,
+37012105-49bd-42ca-9f83-bfb626d0c9f4,UTC South Durham,,school,2U3,10064290,142894
+75a638da-a10e-493c-bc20-22a7b6db63dd,Valentines High School,,school,1OM,10007204,102857
+9a5da24d-a1e1-4002-8778-96d36a872cc3,Valley Invicta Teacher Training (VITT),,school,1CU,10033423,136582
+380f6f7d-2ec3-4561-a2c5-7f3d1271bed2,Valley Invicta Teacher Training with the University of Sussex,,school,3V2,10033423,136582
+3f51c7ea-09dc-451c-a8d8-ac58229356dd,Valley Trust (formerly TRISIS),,school,2HM,10000880,107580
+b3f01f78-3b8d-4962-b618-7169607a4d26,Vantage North Humber Teacher Training,St Mary’s College,school,2V1,10063694,
+950e3fa5-ab99-489e-87ec-8331b49fba34,Ventrus Training school,,school,2BF,10043022,140078
+510a9f7b-83cc-45e9-afed-c0dde14ee5b3,VIAT Scitt,,school,4V2,10086463,
+5dff5c2b-a830-4a49-aeb8-c982b644dd01,Vita London,,school,21C,10063486,144238
+3dfbbccd-1313-4600-8e7a-1535354ef50d,Wade Deacon Trust,,school,1KQ,10007848,111435
+b657ae4b-e840-4216-88cc-5707e09164e2,Waldegrave Training Alliance,,school,1FP,10037849,138461
+e7617ba3-08b6-4140-8b9b-4837a43d8f12,Waldegrave Training Alliance with the University of Sussex,,school,3FP,10037849,138461
+4801dcff-87e4-4c62-aa56-e40c5913bf1f,Waltham Forest Partnership,,school,1AK,10007784,103100
+15774d17-c7c0-4174-a41d-de8b57d45ffd,Wandle Teaching School Hub,,school,13V,10066360,145280
+3a647e45-7ac7-41a4-9413-155962d28fe8,Wandsworth Primary Schools Consortium,,school,W14,10046788,101001
+41fe80c6-d4b7-4b5c-884b-37484340a6cb,Washington and Chester le Street Teacher Training Alliance,,school,2W4,10068929,108818
+d142ec3a-68e7-4d1b-86c1-26b7274a562a,Waterton Academy Trust,,school,2EL,10060843,141799
+047c9a7c-d06d-448a-a6cb-586185512868,Watford Grammar School for Girls,,school,12L,10031380,136289
+ac9c44a8-b782-44be-bd0b-a8cf7512d940,Waverley School in partnership with Birmingham City University,,school,1RH,10060245,142219
+5cb7f126-7ab8-4711-9f15-08885fe79203,Wealden Partnership,,school,1Z2,10002980,114587
+f8c00683-3251-4aec-b322-c024bc4b694d,Wealden Partnership with the University of Sussex,,school,4W3,10002980,114587
+2c80c659-ef89-4cb2-8df3-956cfe8e75f4,Weatherhead High School,,school,21D,10035973,137815
+9af4e4c8-322a-443e-859c-e54c114c7199,Welford on Avon School Teacher Training Hub,,school,2L6,10078076,125528
+f084f978-d74b-44f8-9bdf-22cde4c9ec91,Wessex Teach,,school,1QW,10034818,137163
+9feef4e9-afc1-416e-ad69-d56fafc0a750,West Essex SCITT,Epping Forest Schools Partnership Trust,school,2BB,10067433,
+9509fcc8-d3a4-43dd-937f-23f926df63f7,West London Teacher Training Alliance (Primary),,school,1EL,10036715,137935
+1346ce31-860f-457a-b63c-ea7b07a89031,West London Teacher Training Alliance (Secondary),,school,2BV,10036715,137935
+469f4f01-5c3f-48da-97e4-54092fee292d,West Midlands Consortium,Thomas Telford School,school,W53,10006894,
+0af0c86b-92fd-40a1-b39a-74f3a46b6e80,Westcountry School Trust,,school,4W5,10057945,
+ea6e6341-73ec-4f5e-a066-d8a9469075d2,Wheatley Hill Primary School,,school,3DR,10007159,
+3adecabd-e003-466c-adf0-2a14cb3b54f9,Whitburn Church of England Academy,,school,23F,10038631,136386
+e5be0f2d-095f-484a-a396-c3f1f0ce324b,White Rose Alliance,,school,196,10003643,121699
+9754c3d9-e196-4ec6-b729-fa70b72215bd,White Woman Lane Junior School,,school,1MH,10072966,120914
+6ec1fba7-0bb6-4d94-bfaf-8accdd838bde,Wigan and West Lancashire Catholic School Direct,,school,27Q,10003956,106540
+d667831e-1a02-4696-8bfb-81a1c364762f,Wigan Catholic Primary Alliance,,school,4W4,10003956,106460
+63807640-03ea-4754-a08b-73588b355625,Wildern Partnership,,school,1WH,10033371,
+08a391a4-2677-40e4-9a88-2b516fe1888e,William de Ferrers School,,school,2W1,10033230,136605
+8c8cd580-7c16-4f35-9c3f-a5f31a5ef4b6,William Shrewsbury Primary Partnership,,school,2FM,10065446,145097
+ff430632-f785-4dac-81c4-c89c0c822e38,Winchester Teaching School Alliance,,school,27L,10016269,116407
+64e8b9b1-49a4-42ae-9b25-c38f4645652a,Windsor Teaching Alliance,,school,23R,10005550,70246
+a31f8770-8074-4c9b-aed5-ef167f847431,"Windsor, Ascot and Maidenhead Consortium",,school,1AZ,10005550,70246
+1251c622-d7f7-47f3-9450-649ec3ad3912,Wirral Schools Collaboration (Pensby),,school,1ME,10003957,135497
+df36da74-4a70-4b60-ae51-c5cbee88d4b0,WISE ITT,,school,15Q,10033407,136486
+c6acffa8-1e9d-4f4b-b6b5-18fc069a245f,Wood Green ITT Alliance,,school,1O7,10033330,136616
+2d2cb184-a1ef-42be-b300-8b1085a5bffb,Woodrush Training Consortium,,school,21T,10034168,136924
+29c45396-468a-4846-b686-d47bcb3d189b,Woolwich Poly,,school,1HC,10013305,141163
+a595623a-6c7c-4a24-9bdc-afa37c5d16dc,Wren Academy,,school,19V,10024205,135507
+7c381245-6d18-43d9-96f0-706bf4aa0c56,Wright Robinson College,,school,7Z5,10084213,146239
+2e0c90b5-581f-4068-8b52-e51ec63c81dc,Xavier Teach SouthEast,Xavier Catholic Education Trust,school,2EW,10057399,143367
+3d48a676-2500-450a-b8fa-1be02cea2cbf,Yarrow Schools Alliance,,school,22P,10040125,119466
+8047fac5-c2a3-42ed-94c0-ee94afb41ae5,York College,,school,Y70,10007709,130594
+a24ce050-2e4c-445e-b431-f9acbbaeb9d3,York St John University,York St John University,hei,Y75,10007713,133914
+68ed4a0c-8f17-4144-9cc0-c671bfbf7128,Yorkshire and Humber Teacher Training,,school,2B2,10058237,
+ea39179f-af96-4ad9-b748-75d99d044dbd,Yorkshire Wolds Teacher Training,The Education Alliance,school,2EV,10058551,

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -6,13 +6,20 @@ namespace :example_data do
     raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
 
     PERSONAS.each do |persona_attributes|
-      persona = Persona.find_or_create_by!(
-        first_name: persona_attributes[:first_name],
-        last_name: persona_attributes[:last_name],
-        email: persona_attributes[:email],
-      )
+      persona = Persona.find_or_initialize_by(email: persona_attributes[:email])
+      persona.first_name = persona_attributes[:first_name]
+      persona.last_name = persona_attributes[:last_name]
+      persona.save!
 
       persona.discard! if persona_attributes[:discarded?] && persona.kept?
     end
+
+    ENV["CSV"] = ENV["CSV"] || Rails.root.join("lib/data/seed-providers.csv").to_s
+
+    # Make sure task can be run again (in case it was run before)
+    Rake::Task["import:providers"].reenable
+
+    # Call the import:providers task
+    Rake::Task["import:providers"].invoke
   end
 end

--- a/lib/tasks/import_providers.rake
+++ b/lib/tasks/import_providers.rake
@@ -1,0 +1,47 @@
+require "csv"
+
+require Rails.root.join("config/environment")
+
+namespace :import do
+  desc "Import providers data from CSV file"
+  task providers: :environment do
+    raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
+
+    csv_path = ENV.fetch("CSV", nil)
+    unless File.exist?(csv_path)
+      puts "CSV file not found at #{csv_path}"
+      exit 1
+    end
+
+    puts "Importing providers from #{csv_path}..."
+
+    invalid_count = 0
+    valid_count = 0
+    CSV.foreach(csv_path, headers: true) do |row|
+      provider = Provider.find_or_initialize_by(code: row["code"])
+      provider.operating_name = row["operating_name"]
+      provider.legal_name = row["legal_name"]
+      provider.code = row["code"]
+      provider.ukprn = row["ukprn"]
+      provider.urn = row["urn"]
+      provider.accreditation_status = :unaccredited
+
+      if Provider.provider_types.key?(row["provider_type"])
+        provider.provider_type = row["provider_type"]
+      else
+        puts "Warning: Unknown provider_type '#{row['provider_type']}' for code #{row['code']}"
+        next
+      end
+
+      if provider.save
+        valid_count += 1
+      else
+        invalid_count += 1
+      end
+    rescue StandardError => e
+      puts "Failed to import row #{row.inspect}: #{e.message}"
+    end
+
+    puts "#{valid_count}/#{valid_count + invalid_count} providers was imported."
+  end
+end


### PR DESCRIPTION
### Context
CSV import

### Changes proposed in this pull request
Added a rake task to import the csv for providers

### Guidance to review

Designed so it imports for Review apps and QA, idempont, it will only add new or update existing

https://register-training-providers-pr-150.test.teacherservices.cloud/

```bash
bundle exec rake example_data:generate
# or
bundle exec rake import:providers CSV=some/path/to.csv

```

There is still some validation issue on the raw data hence only a subset is imported and no `scitt`, or `accredited` provider
```
639/851 providers was imported.
```

<img width="117" height="1065" alt="image" src="https://github.com/user-attachments/assets/4e1a5599-3402-4027-ae84-83ecb90a090b" />


