### PR TITLE
[0136] View provider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+
+[*.{css,erb,js,json,rb,scss,sh,yml}]
+indent_size = 2
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -10,4 +10,8 @@ class ProvidersController < ApplicationController
 
     @pagy, @records = pagy(Provider.kept.order_by_operating_name)
   end
+
+  def show
+    @provider = Provider.kept.find(params[:id])
+  end
 end

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -10,7 +10,7 @@ module SummaryHelper
   def provider_summary_cards(providers)
     providers.map do |provider|
       {
-        title: provider.operating_name,
+        title: govuk_link_to(provider.operating_name, provider_path(provider)),
         rows: [
 
           { key: { text: "Provider type" },
@@ -67,6 +67,18 @@ module SummaryHelper
       { key: { text: "Provider code" },
         value: { text: provider.code },
         actions: [{ href: change_path, visually_hidden_text: "provider code" }] },
+    ]
+  end
+
+  def provider_details_rows(provider)
+    [
+      { key: { text: "Provider type" }, value: { text: provider.provider_type_label } },
+      { key: { text: "Accreditation type" }, value: { text: provider.accreditation_status_label } },
+      { key: { text: "Operating name" }, value: { text: provider.operating_name } },
+      { key: { text: "Legal name" }, value: optional_value(provider.legal_name) },
+      { key: { text: "UK provider reference number (UKPRN)" }, value: { text: provider.ukprn } },
+      { key: { text: "Unique reference number (URN)" }, value: optional_value(provider.urn) },
+      { key: { text: "Provider code" }, value: { text: provider.code } },
     ]
   end
 end

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,0 +1,8 @@
+<%= content_for(:breadcrumbs) do %>
+    <%= govuk_back_link(text: "Back", href: providers_path) %>
+<% end %>
+
+<% page_data(title: @provider.operating_name, caption: "Provider", subtitle: "Provider") %>
+
+<h2 class="govuk-heading-m">Provider details</h2>
+<%= govuk_summary_list(rows: provider_details_rows(@provider)) %>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:breadcrumbs) do %>
-    <%= govuk_back_link(text: "Back", href: providers_path) %>
+  <%= govuk_back_link(text: "Back", href: providers_path) %>
 <% end %>
 
 <% page_data(title: @provider.operating_name, caption: "Provider", subtitle: "Provider") %>

--- a/spec/features/end_to_end/providers/view_provider_spec.rb
+++ b/spec/features/end_to_end/providers/view_provider_spec.rb
@@ -1,0 +1,38 @@
+RSpec.feature "View Provider" do
+  scenario "User can view provider details" do
+    given_i_am_an_authenticated_user
+    and_there_is_a_provider
+    when_i_navigate_to_the_view_provider_page_for_a_specific_provider
+    then_i_should_see_the_page_title
+    and_i_should_see_all_details_of_the_provider
+  end
+
+  def when_i_navigate_to_the_view_provider_page_for_a_specific_provider
+    visit "/providers"
+    click_on provider.operating_name
+    and_i_am_taken_to("/providers/#{provider.id}")
+  end
+
+  def then_i_should_see_the_page_title
+    expect(page).to have_heading("h2", "Provider details")
+    expect(page).to have_heading("h1", provider.operating_name)
+    expect(page).to have_title("#{provider.operating_name} - Provider - Register of training providers - GOV.UK")
+  end
+
+  def and_i_should_see_all_details_of_the_provider
+    expect(page).to have_text(provider.operating_name)
+    expect(page).to have_text(provider.provider_type_label)
+    expect(page).to have_text(provider.ukprn)
+    expect(page).to have_text(provider.code)
+    expect(page).to have_text(provider.urn || "Not entered")
+    expect(page).to have_text(provider.legal_name || "Not entered")
+  end
+
+  def and_there_is_a_provider
+    provider
+  end
+
+  def provider
+    @provider ||= create(:provider)
+  end
+end

--- a/spec/helpers/summary_helper_spec.rb
+++ b/spec/helpers/summary_helper_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SummaryHelper, type: :helper do
     let(:providers) { [provider] }
     it "returns the expected not entered hash" do
       expect(helper.provider_summary_cards(providers)).to match_array([{
-        title: provider.operating_name,
+        title: "<a class=\"govuk-link\" href=\"/providers/#{provider.id}\">#{provider.operating_name}</a>",
         rows: [
 
           { key: { text: "Provider type" },
@@ -119,7 +119,7 @@ RSpec.describe SummaryHelper, type: :helper do
     end
 
     context "when all values are present" do
-      let(:provider) { build_stubbed(:provider, legal_name: "Legal Name", urn: "12345") }
+      let(:provider) { build_stubbed(:provider, :scitt) }
 
       it "returns the expected rows without 'Not entered'" do
         expect(helper.provider_rows(provider, change_provider_type_path, change_path)).to eq([
@@ -152,6 +152,80 @@ RSpec.describe SummaryHelper, type: :helper do
             key: { text: "Provider code" },
             value: { text: provider.code },
             actions: [{ href: change_path, visually_hidden_text: "provider code" }]
+          }
+        ])
+      end
+    end
+  end
+
+  describe "#provider_details_rows" do
+    let(:provider) { build_stubbed(:provider, legal_name: nil, urn: nil) }
+
+    it "returns the expected rows with 'Not entered' where applicable" do
+      expect(helper.provider_details_rows(provider)).to eq([
+        {
+          key: { text: "Provider type" },
+          value: { text: provider.provider_type_label },
+        },
+        {
+          key: { text: "Accreditation type" },
+          value: { text: provider.accreditation_status_label },
+        },
+        {
+          key: { text: "Operating name" },
+          value: { text: provider.operating_name },
+        },
+        {
+          key: { text: "Legal name" },
+          value: { text: "Not entered", classes: "govuk-hint" },
+        },
+        {
+          key: { text: "UK provider reference number (UKPRN)" },
+          value: { text: provider.ukprn },
+        },
+        {
+          key: { text: "Unique reference number (URN)" },
+          value: { text: "Not entered", classes: "govuk-hint" },
+        },
+        {
+          key: { text: "Provider code" },
+          value: { text: provider.code },
+        }
+      ])
+    end
+
+    context "when all values are present" do
+      let(:provider) { build_stubbed(:provider, :scitt) }
+
+      it "returns the expected rows without 'Not entered'" do
+        expect(helper.provider_details_rows(provider)).to eq([
+          {
+            key: { text: "Provider type" },
+            value: { text: provider.provider_type_label },
+          },
+          {
+            key: { text: "Accreditation type" },
+            value: { text: provider.accreditation_status_label },
+          },
+          {
+            key: { text: "Operating name" },
+            value: { text: provider.operating_name },
+          },
+          {
+            key: { text: "Legal name" },
+            value: { text: provider.legal_name },
+          },
+          {
+            key: { text: "UK provider reference number (UKPRN)" },
+            value: { text: provider.ukprn },
+          },
+          {
+            key: { text: "Unique reference number (URN)" },
+            value: { text: provider.urn },
+          },
+          {
+            key: { text: "Provider code" },
+            value: { text: provider.code },
           }
         ])
       end

--- a/spec/views/provider/show.html.erb_spec.rb
+++ b/spec/views/provider/show.html.erb_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "providers/show.html.erb", type: :view do
+  let(:provider) { build_stubbed(:provider, :school) }
+  let(:goto) { nil }
+
+  before do
+    assign(:provider, provider)
+    allow(view).to receive(:page_data)
+
+    render
+  end
+
+  it "calls page_data" do
+    expect(view).to have_received(:page_data).with({
+      title: provider.operating_name,
+      subtitle: "Provider",
+      caption: "Provider",
+
+    })
+  end
+
+  it "renders heading" do
+    expect(rendered).to have_heading("h2", "Provider details")
+  end
+
+  it "renders the provider" do
+    expect(rendered).to have_selector(".govuk-summary-list__key", text: "Provider type")
+    expect(rendered).to have_selector(".govuk-summary-list__value", text: provider.provider_type_label)
+    expect(rendered).to have_selector(".govuk-summary-list__key", text: "Accreditation type")
+    expect(rendered).to have_selector(".govuk-summary-list__value", text: provider.accreditation_status_label)
+    expect(rendered).to have_selector(".govuk-summary-list__key", text: "Operating name")
+    expect(rendered).to have_selector(".govuk-summary-list__value", text: provider.operating_name)
+    expect(rendered).to have_selector(".govuk-summary-list__key", text: "Legal name")
+    expect(rendered).to have_selector(".govuk-summary-list__value", text: provider.legal_name)
+    expect(rendered).to have_selector(".govuk-summary-list__key", text: "UK provider reference number (UKPRN)")
+    expect(rendered).to have_selector(".govuk-summary-list__value", text: provider.ukprn)
+    expect(rendered).to have_selector(".govuk-summary-list__key", text: "Unique reference number (URN)")
+    expect(rendered).to have_selector(".govuk-summary-list__value", text: provider.urn)
+    expect(rendered).to have_selector(".govuk-summary-list__key", text: "Provider code")
+    expect(rendered).to have_selector(".govuk-summary-list__value", text: provider.code)
+  end
+
+  it "renders the back link" do
+    expect(view.content_for(:breadcrumbs)).to have_back_link(providers_path)
+  end
+end

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     operating_name { [legal_name, Faker::Company.name].compact.sample }
 
     urn do
-      if %i[school scitt].include?(provider_type)
+      if %i[school scitt].include?(provider_type.to_sym)
         Faker::Number.unique.number(digits: rand(5..6)).to_s
       end
     end


### PR DESCRIPTION
### Context
View provider

### Changes proposed in this pull request
Added ability to view a provider

### Guidance to review

On the listing of provider the operating name/title is now clickable
<img width="1260" height="988" alt="image" src="https://github.com/user-attachments/assets/17b33b42-ac2b-4b8c-9b96-1693e58d98a8" />


<img width="1920" height="2192" alt="image" src="https://github.com/user-attachments/assets/fd46528e-f70c-4e1c-b84f-2c4a4d791aa2" />

