### PR TITLE
Configure RoTP app to run as non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 
+# Create non-root user and group
+RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
+
 # libpq: required to run postgres
 RUN apk add --no-cache libpq
 
@@ -70,8 +73,15 @@ RUN apk add --no-cache libpq
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+# Change ownership only for directories that need write access
+RUN chown -R appuser:appgroup /app/tmp
+
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
+# Use non-root user
+USER 10001
+
 ENTRYPOINT ["./bin/rails", "server"]
+
 CMD ["-b", "0.0.0.0"]

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -50,6 +50,8 @@ module "web_application" {
   probe_path = "/ping"
   replicas     = var.replicas
 
+  run_as_non_root = true
+
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
@@ -65,6 +67,8 @@ module "worker_application" {
   depends_on = [module.migration]
 
   is_web = false
+
+  run_as_non_root = true
 
   name         = "worker"
   namespace    = var.namespace


### PR DESCRIPTION
## Context
Configure RoTP app to run as non root

## Changes proposed in this pull request
Configure RoTP app to run as non root

## Guidance to review
Check the review app

## Link to Trello card
https://trello.com/c/HTFH3K0a/2412-security-aks-containers-run-as-non-root-user-rtp

## Checklist

- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [ ]  Tested by running locally