### PR TITLE
[0177] Service error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,10 +9,6 @@ class ErrorsController < ApplicationController
     render "unprocessable_entity", status: :unprocessable_entity
   end
 
-  def too_many_requests
-    render "too_many_requests", status: :too_many_requests
-  end
-
   def internal_server_error
     render "internal_server_error", status: :internal_server_error
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,7 +1,8 @@
 class ErrorsController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate
 
   def not_found
+    check_user_is_authenticated
     render "not_found", status: :not_found
   end
 
@@ -11,5 +12,11 @@ class ErrorsController < ApplicationController
 
   def internal_server_error
     render "internal_server_error", status: :internal_server_error
+  end
+
+private
+
+  def check_user_is_authenticated
+    nil if authenticated?
   end
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,18 +1,13 @@
 <%= content_for :page_title, "Sorry, there’s a problem with the service" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
+<h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
 
-    <p class="govuk-body">Try again later.</p>
+<p class="govuk-body">Try again later.</p>
 
-    <p class="govuk-body">
-      If you reached this page after submitting information then it has not
-      been saved. You’ll need to enter it again when the service is available.
-    </p>
-    <p class="govuk-body">
-      If you have any questions, please email us at <a class="govuk-link"
-        href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  If you reached this page after submitting information then it has not
+  been saved. You’ll need to enter it again when the service is available.
+</p>
+<p class="govuk-body">
+  If you have any questions, email <%= support_email %></a>.
+</p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,18 +1,12 @@
 <%= content_for :page_title, "Page not found" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Page not found</h1>
-    <p class="govuk-body">
-      If you entered a web address, check it is correct.
-    </p>
-    <p class="govuk-body">
-      If you pasted the web address, check you copied the entire address.
-    </p>
-    <p class="govuk-body">
-      If the web address is correct or you selected a link or button and you
-      need to speak to someone about this problem, contact the <%= t("service.name") %> team:
-      <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
-    </p>
-  </div>
-</div>
+<h1 class="govuk-heading-l">Page not found</h1>
+<p class="govuk-body">
+  If you entered a web address, check it is correct.
+</p>
+<p class="govuk-body">
+  If you pasted the web address, check you copied the entire address.
+</p>
+<p class="govuk-body">
+  If you have any questions, email <%= support_email %>.</p>
+</p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,14 +1,13 @@
 <%= content_for :page_title, "Sorry, there’s a problem with the service" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
+<h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
 
-    <p class="govuk-body">Try again later.</p>
+<p class="govuk-body">Try again later.</p>
 
-    <p class="govuk-body">
-      If you continue to see this error contact the <%= t("service.name") %> team:
-      <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  If you reached this page after submitting information then it has not
+  been saved. You’ll need to enter it again when the service is available.
+</p>
+<p class="govuk-body">
+  If you have any questions, email <%= support_email %></a>.
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
   scope via: :all do
     get "/404", to: "errors#not_found"
     get "/422", to: "errors#unprocessable_entity"
-    get "/429", to: "errors#too_many_requests"
     get "/500", to: "errors#internal_server_error"
   end
 

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Error Pages", type: :request do
+  describe "GET /404" do
+    it "renders the 404 error page" do
+      get "/404"
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+  end
+
+  describe "GET /422" do
+    it "renders the 422 error page" do
+      get "/422"
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Sorry, there’s a problem with the service")
+    end
+  end
+
+  describe "GET /500" do
+    it "renders the 500 error page" do
+      get "/500"
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.body).to include("Sorry, there’s a problem with the service")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Service error pages

### Changes proposed in this pull request
Amended `not_found`
Amended `unprocessable_entity`
Amended `internal_server_error`

### Guidance to review

#### Page not found

`not_found` will show if the user is signed in or not

Design history for [Page not found](https://becoming-a-teacher.design-history.education.gov.uk/register-of-training-providers/service-error-pages/#page-not-found)

signed in or not and then visit
https://register-training-providers-pr-169.test.teacherservices.cloud/404/

##### Signed out
<img width="1980" height="1358" alt="image" src="https://github.com/user-attachments/assets/687c18e4-983c-4508-8211-563046c10b3d" />

##### Signed in
> notice the navigation components
<img width="1980" height="1478" alt="image" src="https://github.com/user-attachments/assets/9c14924a-cc23-4e15-9b0d-63d79c42bcb8" />

#### The service is unavailable 
`internal_server_error` and `unprocessable_entity` are the same, (it will not show if the user is signed in or not)

https://register-training-providers-pr-169.test.teacherservices.cloud/422
https://register-training-providers-pr-169.test.teacherservices.cloud/500

Design history for [The service is unavailable](https://becoming-a-teacher.design-history.education.gov.uk/register-of-training-providers/service-error-pages/#the-service-is-unavailable)

> unprocessable_entity with http code 422 was done as the error content can be related

<img width="1980" height="1488" alt="image" src="https://github.com/user-attachments/assets/d986b2cc-8deb-4a63-b811-040213413f1a" />


#### Account not recognised 
This was previous configured, did not change in PR, only added for completeness

https://register-training-providers-pr-169.test.teacherservices.cloud/sign-in/user-not-found

Design history for [Account not recognised](https://becoming-a-teacher.design-history.education.gov.uk/register-of-training-providers/service-error-pages/#account-not-recognised)

<img width="1980" height="1398" alt="image" src="https://github.com/user-attachments/assets/f477d955-ac96-49c8-b8d3-7112eb58d238" />


