### PR TITLE
Add variable for PostgreSQL version

### DIFF
--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -11,7 +11,7 @@ module "postgres" {
   use_azure                   = var.deploy_azure_backing_services
   azure_enable_monitoring     = var.enable_monitoring
   azure_enable_backup_storage = var.enable_postgres_backup_storage
-  server_version              = "16"
+  server_version              = var.postgres_version
   azure_maintenance_window    = var.azure_maintenance_window
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_sku_name              = var.postgres_flexible_server_sku

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -130,3 +130,4 @@ variable "job_name" {
   default     = "migrations"
 }
 
+variable "postgres_version" { default = 16 }


### PR DESCRIPTION
## Context
Add variable for PostgreSQL version so its possible to upgrade the postgres  server per environment

## Changes proposed in this pull request
Add variable for PostgreSQL version

## Guidance to review
make env terraform-plan
Plan shows no changes as the default postgres version is set to 16

## Link to Trello card
https://trello.com/c/u1ZbJf5h/2450-rotp-change-postgresql-version-to-a-variable

## Checklist
- [ ]  Attach to Trello card
- [ ]  Rebased main
- [ ]  Cleaned commit history
- [ ]  Tested by running locally