### PR TITLE
[0231] Added archived tag

### DIFF
--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -9,8 +9,11 @@ module SummaryHelper
 
   def provider_summary_cards(providers)
     providers.map do |provider|
+      tag = [" ", govuk_tag(text: "Archived", classes: "govuk-!-margin-left-1")] if provider.archived?
+
       {
-        title: govuk_link_to(provider.operating_name, provider_path(provider)),
+        title: safe_join([govuk_link_to(provider.operating_name, provider_path(provider)),
+                          tag]),
         rows: [
 
           { key: { text: "Provider type" },

--- a/spec/views/provider/index.html.erb_spec.rb
+++ b/spec/views/provider/index.html.erb_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe "providers/index.html.erb", type: :view do
   let(:provider_1) { build_stubbed(:provider, operating_name: "Academy", legal_name: "Academy", urn: "50001") }
   let(:provider_2) { build_stubbed(:provider, operating_name: "Big School", legal_name: "Big old school", urn: "50002") }
-  let(:providers) { [provider_1, provider_2] }
+  let(:provider_3) { build_stubbed(:provider, :archived, operating_name: "College", legal_name: "New College", urn: "50003") }
+  let(:providers) { [provider_1, provider_2, provider_3] }
   let(:count) { providers.size }
   let(:pagy) { Pagy.new(count: count, page: 1) }
 
@@ -27,11 +28,17 @@ RSpec.describe "providers/index.html.erb", type: :view do
   end
 
   it "calls page_data with govuk_number count" do
-    expect(view).to have_received(:page_data).with(title: "Providers (2)")
+    expect(view).to have_received(:page_data).with(title: "Providers (3)")
   end
 
   it "renders the add provider button" do
     expect(rendered_custom_layout).to have_link("Add provider", href: "/providers/new")
+  end
+
+  it "renders the correct title for provider summary cards" do
+    expect(rendered_custom_layout).to have_css(".govuk-summary-card__title", text: provider_1.operating_name)
+    expect(rendered_custom_layout).to have_css(".govuk-summary-card__title", text: provider_2.operating_name)
+    expect(rendered_custom_layout).to have_css(".govuk-summary-card__title", text: "#{provider_3.operating_name} Archived")
   end
 
   it "does not renders the pagination component" do


### PR DESCRIPTION
### Context
The archived tag

### Changes proposed in this pull request
Added archived tag for the provider on the provider list page

### Guidance to review
Given a provider 
when it is archived 
then the archived tag is shown on the provider list page

#### Screensnot
<img width="2966" height="3582" alt="image" src="https://github.com/user-attachments/assets/c4172821-9662-42a0-a898-ba19eeed6b02" />


