### PR TITLE
[0236] Fixed ordering of error messages

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -51,9 +51,9 @@ class Provider < ApplicationRecord
 
   validates :operating_name, presence: true
   validates :ukprn, presence: true, format: { with: /\A[0-9]{8}\z/ }, length: { is: 8 }
-  validates :code, presence: true, uniqueness: true, format: { with: /\A[A-Z0-9]{3}\z/i }, length: { is: 3 }
   validates :urn, presence: true, format: { with: /\A[0-9]{5,6}\z/ }, length: { in: 5..6 },
                   if: :requires_urn?
+  validates :code, presence: true, uniqueness: true, format: { with: /\A[A-Z0-9]{3}\z/i }, length: { is: 3 }
 
   before_save :upcase_code
   before_save :update_searchable

--- a/spec/features/end_to_end/providers/change_provider_details_spec.rb
+++ b/spec/features/end_to_end/providers/change_provider_details_spec.rb
@@ -29,8 +29,8 @@ RSpec.feature "Change Provider Details" do
     and_i_can_see_the_error_summary(
       "Enter operating name",
       "Enter UK provider reference number (UKPRN)",
-      "Enter provider code",
       "Enter unique reference number (URN)",
+      "Enter provider code",
     )
 
     and_i_fill_in_the_provider_details_form

--- a/spec/views/provider/details/new.html.erb_spec.rb
+++ b/spec/views/provider/details/new.html.erb_spec.rb
@@ -72,8 +72,10 @@ RSpec.describe "providers/details/new.html.erb", type: :view do
 
       it "renders the error summary" do
         expect(view.content_for(:page_alerts)).to have_error_summary(
-          "Enter operating name", "Enter UK provider reference number (UKPRN)", "Enter provider code",
-          "Enter unique reference number (URN)"
+          "Enter operating name",
+          "Enter UK provider reference number (UKPRN)",
+          "Enter unique reference number (URN)",
+          "Enter provider code",
         )
       end
     end
@@ -95,8 +97,10 @@ RSpec.describe "providers/details/new.html.erb", type: :view do
 
       it "renders the error summary" do
         expect(view.content_for(:page_alerts)).to have_error_summary(
-          "Enter operating name", "Enter UK provider reference number (UKPRN)", "Enter provider code",
-          "Enter unique reference number (URN)"
+          "Enter operating name",
+          "Enter UK provider reference number (UKPRN)",
+          "Enter unique reference number (URN)",
+          "Enter provider code",
         )
       end
     end
@@ -118,7 +122,9 @@ RSpec.describe "providers/details/new.html.erb", type: :view do
 
       it "renders the error summary" do
         expect(view.content_for(:page_alerts)).to have_error_summary(
-          "Enter operating name", "Enter UK provider reference number (UKPRN)", "Enter provider code"
+          "Enter operating name",
+          "Enter UK provider reference number (UKPRN)",
+          "Enter provider code"
         )
       end
     end

--- a/spec/views/provider/edit.html.erb_spec.rb
+++ b/spec/views/provider/edit.html.erb_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe "providers/edit.html.erb", type: :view do
         expect(view.content_for(:page_alerts)).to have_error_summary(
           "Enter operating name",
           "Enter UK provider reference number (UKPRN)",
+          "Enter unique reference number (URN)",
           "Enter provider code",
-          "Enter unique reference number (URN)"
         )
       end
     end
@@ -105,8 +105,8 @@ RSpec.describe "providers/edit.html.erb", type: :view do
         expect(view.content_for(:page_alerts)).to have_error_summary(
           "Enter operating name",
           "Enter UK provider reference number (UKPRN)",
+          "Enter unique reference number (URN)",
           "Enter provider code",
-          "Enter unique reference number (URN)"
         )
       end
     end


### PR DESCRIPTION
### Context
Ordering of error messages
### Changes proposed in this pull request
Fixed the ordering of errors


### Guidance to review
Is it ordered correctly?

#### Screensnot
<img width="1920" height="3050" alt="image" src="https://github.com/user-attachments/assets/ac2b62d4-df98-41e5-904c-340f655364a0" />

