### PR TITLE
[0437, 0440] Add academic years to be displayed on provider summary card

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -39,7 +39,7 @@ $govuk-assets-path: "/";
   code {
     @include govuk-font($size: 19);
     font-family: monospace;
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 
   pre {

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -9,7 +9,7 @@ module Api
         .joins(:academic_years)
         .where(academic_years: { id: AcademicYear.for_year(academic_year) })
 
-      providers = scope.order(:updated_at)
+      providers = scope.order(:updated_at, :operating_name, :id)
 
       data = providers.map do |p|
         p.as_json(

--- a/app/helpers/academic_year_helper.rb
+++ b/app/helpers/academic_year_helper.rb
@@ -10,8 +10,10 @@ module AcademicYearHelper
     return content_tag(:p, "No academic years") if academic_years.blank?
 
     if use_details
-      first_group, remaining_group = academic_years.each_slice(3).to_a
+      first_group, *remaining_group = academic_years.each_slice(3).to_a
       primary = academic_years_bullet_list(first_group)
+
+      remaining_group = remaining_group.flatten
 
       if remaining_group.present?
         more = academic_years_bullet_list(remaining_group)

--- a/app/helpers/academic_year_helper.rb
+++ b/app/helpers/academic_year_helper.rb
@@ -1,22 +1,39 @@
 module AcademicYearHelper
-  def academic_years_row(academic_years)
-    academic_years_html = tag.ul(class: "govuk-list govuk-list--bullet") do
-      academic_years.collect do |academic_year|
-        concat tag.li(display_academic_year(academic_year))
-      end
-    end
+  def academic_years_row(academic_years, use_details)
+    {
+      key: { text: "Academic years" },
+      value: { text: academic_years_html(academic_years, use_details) }
+    }
+  end
 
-    { key: { text: "Academic years" },
-      value: { text: academic_years_html } }
+  def academic_years_html(academic_years, use_details)
+    return content_tag(:p, "No academic years") if academic_years.blank?
+
+    if use_details
+      first_group, remaining_group = academic_years.each_slice(3).to_a
+      primary = academic_years_bullet_list(first_group)
+
+      if remaining_group.present?
+        more = academic_years_bullet_list(remaining_group)
+        safe_join([primary, govuk_details(summary_text: "More academic years", text: more)])
+      else
+        primary
+      end
+    else
+      academic_years_bullet_list(academic_years)
+    end
+  end
+
+  def academic_years_bullet_list(items)
+    content_tag(:ul, class: "govuk-list govuk-list--bullet") do
+      items.map { |year| content_tag(:li, display_academic_year(year)) }.join.html_safe
+    end
   end
 
   def display_academic_year(academic_year)
-    academic_year_text = "#{academic_year.duration.begin.year} to #{academic_year.duration.end.year}"
-    [:current, :last, :next].each do |label|
-      academic_year_text += " - #{label}" if academic_year.send(:"#{label}?")
-    end
-
-    academic_year_text
+    base = "#{academic_year.duration.begin.year} to #{academic_year.duration.end.year}"
+    labels = %i[current last next].select { |l| academic_year.public_send("#{l}?") }
+    labels.empty? ? base : "#{base} - #{labels.join(' - ')}"
   end
 
   def academic_year_helper_text(academic_year)

--- a/app/helpers/partnership_helper.rb
+++ b/app/helpers/partnership_helper.rb
@@ -45,7 +45,7 @@ module PartnershipHelper
     end
     rows << dates_row
 
-    years_row = academic_years_row(partnership.academic_years)
+    years_row = academic_years_row(partnership.academic_years, false)
     if change_paths[:academic_years].present?
       years_row[:actions] = [{ href: change_paths[:academic_years], visually_hidden_text: "academic years" }]
     end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,12 +1,13 @@
 module ProviderHelper
   # Base rows for displaying provider details in summary cards/lists.
   # Used by: provider index cards, provider show page, activity log.
-  def provider_summary_card_rows(provider, hide_provider_code: false, hide_ukprn: false, hide_urn: false)
+  def provider_summary_card_rows(provider, hide_provider_code: false, hide_ukprn: false, hide_urn: false,
+                                 use_details_for_academic_years_row: false)
     summary_card_rows = [
       { key: { text: "Provider type" }, value: { text: provider.provider_type_label } },
       { key: { text: "Accreditation status" }, value: { text: provider.accreditation_status_label } },
       { key: { text: "Operating name" }, value: { text: provider.operating_name } },
-      { key: { text: "Legal name" }, value: optional_value(provider.legal_name) }
+      { key: { text: "Legal name" }, value: optional_value(provider.legal_name) },
     ]
 
     summary_card_rows += [{ key: { text: "UK provider reference number (UKPRN)" },
@@ -15,6 +16,9 @@ module ProviderHelper
                             value: optional_value(provider.urn) }] unless hide_urn
     summary_card_rows += [{ key: { text: "Provider code" },
                             value: { text: provider.code } }] unless hide_provider_code
+
+    summary_card_rows += [academic_years_row(provider.academic_years.order(duration: :desc),
+                                             use_details_for_academic_years_row)]
 
     summary_card_rows
   end
@@ -57,7 +61,8 @@ module ProviderHelper
           provider,
           hide_provider_code: true,
           hide_ukprn: true,
-          hide_urn: true
+          hide_urn: true,
+          use_details_for_academic_years_row: true
         )
       }
     end
@@ -110,7 +115,8 @@ module ProviderHelper
       "Legal name" => "legal name",
       "UK provider reference number (UKPRN)" => "UK provider reference number (UKPRN)",
       "Unique reference number (URN)" => "unique reference number (URN)",
-      "Provider code" => "provider code"
+      "Provider code" => "provider code",
+      "Academic years" => "academic years"
     }
 
     rows.each do |row|

--- a/public/openapi/v0.yaml
+++ b/public/openapi/v0.yaml
@@ -84,7 +84,7 @@ paths:
         required: true
         schema:
           type: string
-        example: test_a48205de0776aee35373e13f6bd5ca66c3c2428e27d2562bcc6ea6be3bcad960
+        example: test_d5ca66c3c2428e27d2562bcc6ea6be3bcad9609fbfa9cb89e691676c8690fd9c
         description: A valid API token must be provided in the Authorization header
           to access this endpoint.
       - name: academic_year
@@ -158,53 +158,53 @@ paths:
               example:
                 data:
                 - id: 7bcf4928-a0c7-4fa7-aa46-d4297eec31e0
-                  operating_name: School 7320
+                  operating_name: Higher education institution (HEI) 7320
+                  provider_type: hei
+                  code: 8BN
+                  accreditation_status: unaccredited
+                  ukprn: '77336264'
+                  urn:
+                  updated_at: '2025-09-15T11:34:56Z'
+                - id: bc668b2e-9fa2-4bda-a2f4-97f95d391cf8
+                  operating_name: Higher education institution (HEI) 9494
+                  provider_type: hei
+                  code: 7LA
+                  accreditation_status: accredited
+                  ukprn: '80063525'
+                  urn:
+                  updated_at: '2025-09-15T11:34:56Z'
+                - id: e375bccb-26e8-4dba-a8bc-eca867da9e3b
+                  operating_name: Other 7598
+                  provider_type: other
+                  code: 95D
+                  accreditation_status: unaccredited
+                  ukprn: '69846690'
+                  urn:
+                  updated_at: '2025-09-15T11:34:56Z'
+                - id: 3c677f94-76cd-4e07-967e-3a6e78f961eb
+                  operating_name: Other 9808
+                  provider_type: other
+                  code: 3IU
+                  accreditation_status: accredited
+                  ukprn: '17855396'
+                  urn:
+                  updated_at: '2025-09-15T11:34:56Z'
+                - id: 44ea1b4b-e474-4334-930a-5a71eaa3547d
+                  operating_name: School 5025
                   provider_type: school
-                  code: 98W
+                  code: FA9
                   accreditation_status: unaccredited
-                  ukprn: '52849471'
-                  urn: '31673'
+                  ukprn: '24625549'
+                  urn: '543380'
                   updated_at: '2025-09-15T11:34:56Z'
-                - id: 3172f5c2-8bd3-440c-807e-5d4c971e888c
+                - id: 03bfb99e-9e20-4715-9401-f346354fc1e4
                   operating_name: School-centred initial teacher training (SCITT)
-                    1063
+                    7475
                   provider_type: scitt
-                  code: 93W
+                  code: PAZ
                   accreditation_status: accredited
-                  ukprn: '69843359'
-                  urn: '625172'
-                  updated_at: '2025-09-15T11:34:56Z'
-                - id: 06f04c46-bf0f-4161-8f29-a986bf4e548f
-                  operating_name: Higher education institution (HEI) 1668
-                  provider_type: hei
-                  code: 4LK
-                  accreditation_status: accredited
-                  ukprn: '98088407'
-                  urn:
-                  updated_at: '2025-09-15T11:34:56Z'
-                - id: 2c0f6229-c3a5-4760-a960-de8d0fb16de6
-                  operating_name: Higher education institution (HEI) 7480
-                  provider_type: hei
-                  code: ETU
-                  accreditation_status: unaccredited
-                  ukprn: '12544338'
-                  urn:
-                  updated_at: '2025-09-15T11:34:56Z'
-                - id: bfe71f91-e0fe-40bd-affa-2839e412999a
-                  operating_name: Other 4570
-                  provider_type: other
-                  code: '917'
-                  accreditation_status: accredited
-                  ukprn: '56255493'
-                  urn:
-                  updated_at: '2025-09-15T11:34:56Z'
-                - id: 7ca5c9b9-3427-49c4-9ba7-888b37b6fe9c
-                  operating_name: Other 6343
-                  provider_type: other
-                  code: WNO
-                  accreditation_status: unaccredited
-                  ukprn: '19092440'
-                  urn:
+                  ukprn: '34400987'
+                  urn: '443670'
                   updated_at: '2025-09-15T11:34:56Z'
         '401':
           description: returns 401 Unauthorized for invalid token

--- a/spec/helpers/academic_year_helper_spec.rb
+++ b/spec/helpers/academic_year_helper_spec.rb
@@ -1,13 +1,26 @@
 require "rails_helper"
 
 RSpec.describe AcademicYearHelper, type: :helper do
-  describe "#academic_years_row" do
-    let(:academic_years) { build_list(:academic_year, 2) }
+  def build_years(count)
+    base = AcademicYearCalculator.current_academic_year
 
-    it "returns a hash with :key and :value" do
+    (0...count).map do |i|
+      build(:academic_year, academic_year: base - i)
+    end
+  end
+
+  describe "#academic_years_row" do
+    let(:academic_years) do
+      [
+        build(:academic_year, :previous),
+        build(:academic_year, :current)
+      ]
+    end
+
+    it "returns key/value structure" do
       result = helper.academic_years_row(academic_years, false)
 
-      expect(result).to include(:key, :value)
+      expect(result.keys).to contain_exactly(:key, :value)
       expect(result[:key][:text]).to eq("Academic years")
     end
 
@@ -15,110 +28,107 @@ RSpec.describe AcademicYearHelper, type: :helper do
       result = helper.academic_years_row(academic_years, false)
       html = result[:value][:text]
 
-      expect(html).to include("govuk-list")
-      expect(html).to include("govuk-list--bullet")
+      expect(html).to include("govuk-list", "govuk-list--bullet")
       expect(html).to include("<ul")
       expect(html).to include("<li")
     end
 
-    it "wraps extra years in a <details> component when use_details is true" do
-      years = build_list(:academic_year, 5)
-
-      result = helper.academic_years_row(years, true)
-      html = result[:value][:text]
-
-      expect(html).to include("<ul").and include("<li")
-      expect(html).to include("More academic years")
-      expect(html.scan("<ul").size).to eq(2)
-    end
-
-    it "includes the formatted text for each academic year" do
-      academic_years.each do |ay|
-        allow(helper).to receive(:display_academic_year)
-          .with(ay)
-          .and_return("formatted #{ay.duration.begin.year}")
-      end
-
+    it "renders all academic years in output" do
       result = helper.academic_years_row(academic_years, false)
       html = result[:value][:text]
 
-      academic_years.each do |ay|
-        expect(html).to include("formatted #{ay.duration.begin.year}")
+      academic_years.each do |year|
+        expect(html).to include(year.duration.begin.year.to_s)
+        expect(html).to include(year.duration.end.year.to_s)
+      end
+    end
+  end
+
+  describe "#academic_years_html" do
+    it "shows placeholder when empty" do
+      expect(helper.academic_years_html([], false))
+        .to include("No academic years")
+    end
+
+    it "renders a single list when 3 or fewer items" do
+      html = helper.academic_years_html(build_years(3), true)
+
+      expect(html.scan("<ul").size).to eq(1)
+      expect(html).not_to include("More academic years")
+    end
+
+    it "splits into primary list and details when more than 3 items" do
+      html = helper.academic_years_html(build_years(6), true)
+
+      expect(html.scan("<ul").size).to eq(2)
+      expect(html).to include("More academic years")
+      expect(html).to include("<details")
+    end
+  end
+
+  describe "grouping behaviour (slice of 3)" do
+    it "keeps first 3 items in primary list and rest in details" do
+      years = build_years(8)
+
+      html = helper.academic_years_html(years, true)
+
+      primary = years.first(3)
+      overflow = years.drop(3)
+
+      primary.each do |year|
+        expect(html).to include(year.duration.begin.year.to_s)
+      end
+
+      overflow.each do |year|
+        expect(html).to include(year.duration.begin.year.to_s)
+      end
+    end
+
+    it "does not drop any academic years during grouping" do
+      years = build_years(8)
+
+      html = helper.academic_years_html(years, true)
+
+      years.each do |year|
+        expect(html).to include(year.duration.begin.year.to_s)
       end
     end
   end
 
   describe "#display_academic_year" do
-    let(:start_year) { 2023 }
-    let(:end_year)   { 2024 }
-    let(:duration)   { Date.new(start_year, 8, 1)..Date.new(end_year, 7, 31) }
-
     let(:academic_year) do
-      instance_double(
-        "AcademicYear",
-        duration: duration,
-        current?: false,
-        last?: false,
-        next?: false
-      )
+      build(:academic_year, academic_year: 2023)
     end
 
-    it "formats the academic year range" do
+    it "formats year range correctly" do
       expect(helper.display_academic_year(academic_year))
-        .to eq("#{start_year} to #{end_year}")
+        .to include("2023 to 2024")
     end
 
-    %i[current last next].each do |label|
-      context "when #{label}" do
-        before { allow(academic_year).to receive(:"#{label}?").and_return(true) }
+    it "adds label when present" do
+      allow(academic_year).to receive(:next?).and_return(true)
 
-        it "adds the #{label} label" do
-          result = helper.display_academic_year(academic_year)
-          expect(result).to include(label.to_s)
-        end
-      end
+      expect(helper.display_academic_year(academic_year))
+        .to include("next")
     end
 
-    context "when multiple labels apply" do
-      before do
-        allow(academic_year).to receive(:current?).and_return(true)
-        allow(academic_year).to receive(:next?).and_return(true)
-      end
+    it "orders multiple labels correctly" do
+      allow(academic_year).to receive(:current?).and_return(true)
+      allow(academic_year).to receive(:next?).and_return(true)
 
-      it "adds all applicable labels in order" do
-        result = helper.display_academic_year(academic_year)
-        expect(result).to include("current")
-        expect(result).to include("next")
-        expect(result).to match(%r{#{start_year} to #{end_year} - current - next})
-      end
+      expect(helper.display_academic_year(academic_year))
+        .to eq("2023 to 2024 - current - next")
     end
   end
 
   describe "#academic_year_helper_text" do
-    let(:start_year) { 2023 }
-    let(:end_year)   { 2024 }
-    let(:duration)   { Date.new(start_year, 8, 1)..Date.new(end_year, 7, 31) }
-
-    let(:academic_year) { instance_double("AcademicYear", duration:) }
-
-    it "returns the correctly formatted text" do
-      expect(helper.academic_year_helper_text(academic_year)).to eq(
-        "Starts on 1 August #{start_year}, ends on 31 July #{end_year}"
-      )
+    let(:academic_year) do
+      build(:academic_year, academic_year: 2023)
     end
 
-    it "uses the beginning year of the duration" do
-      expect(academic_year.duration.begin.year).to eq(start_year)
-
-      result = helper.academic_year_helper_text(academic_year)
-      expect(result).to include(start_year.to_s)
-    end
-
-    it "uses the ending year of the duration" do
-      expect(academic_year.duration.end.year).to eq(end_year)
-
-      result = helper.academic_year_helper_text(academic_year)
-      expect(result).to include(end_year.to_s)
+    it "formats helper text correctly" do
+      expect(helper.academic_year_helper_text(academic_year))
+        .to eq("Starts on 1 August 2023, ends on 31 July 2024")
     end
   end
 end

--- a/spec/helpers/academic_year_helper_spec.rb
+++ b/spec/helpers/academic_year_helper_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe AcademicYearHelper, type: :helper do
   describe "#academic_years_row" do
     let(:academic_years) { build_list(:academic_year, 2) }
 
-    it "returns a hash with key and value" do
-      result = helper.academic_years_row(academic_years)
+    it "returns a hash with :key and :value" do
+      result = helper.academic_years_row(academic_years, false)
 
       expect(result).to include(:key, :value)
       expect(result[:key][:text]).to eq("Academic years")
     end
 
-    it "renders a bullet list of academic years" do
-      result = helper.academic_years_row(academic_years)
+    it "renders a bullet list when use_details is false" do
+      result = helper.academic_years_row(academic_years, false)
       html = result[:value][:text]
 
       expect(html).to include("govuk-list")
@@ -21,14 +21,25 @@ RSpec.describe AcademicYearHelper, type: :helper do
       expect(html).to include("<li")
     end
 
-    it "includes each academic year display text" do
+    it "wraps extra years in a <details> component when use_details is true" do
+      years = build_list(:academic_year, 5)
+
+      result = helper.academic_years_row(years, true)
+      html = result[:value][:text]
+
+      expect(html).to include("<ul").and include("<li")
+      expect(html).to include("More academic years")
+      expect(html.scan("<ul").size).to eq(2)
+    end
+
+    it "includes the formatted text for each academic year" do
       academic_years.each do |ay|
         allow(helper).to receive(:display_academic_year)
           .with(ay)
           .and_return("formatted #{ay.duration.begin.year}")
       end
 
-      result = helper.academic_years_row(academic_years)
+      result = helper.academic_years_row(academic_years, false)
       html = result[:value][:text]
 
       academic_years.each do |ay|
@@ -39,8 +50,8 @@ RSpec.describe AcademicYearHelper, type: :helper do
 
   describe "#display_academic_year" do
     let(:start_year) { 2023 }
-    let(:end_year) { 2024 }
-    let(:duration) { Date.new(start_year, 8, 1)..Date.new(end_year, 7, 31) }
+    let(:end_year)   { 2024 }
+    let(:duration)   { Date.new(start_year, 8, 1)..Date.new(end_year, 7, 31) }
 
     let(:academic_year) do
       instance_double(
@@ -53,44 +64,18 @@ RSpec.describe AcademicYearHelper, type: :helper do
     end
 
     it "formats the academic year range" do
-      result = helper.display_academic_year(academic_year)
-
-      expect(result).to eq("#{start_year} to #{end_year}")
+      expect(helper.display_academic_year(academic_year))
+        .to eq("#{start_year} to #{end_year}")
     end
 
-    context "when current" do
-      before do
-        allow(academic_year).to receive(:current?).and_return(true)
-      end
+    %i[current last next].each do |label|
+      context "when #{label}" do
+        before { allow(academic_year).to receive(:"#{label}?").and_return(true) }
 
-      it "adds current label" do
-        result = helper.display_academic_year(academic_year)
-
-        expect(result).to include("current")
-      end
-    end
-
-    context "when last" do
-      before do
-        allow(academic_year).to receive(:last?).and_return(true)
-      end
-
-      it "adds last label" do
-        result = helper.display_academic_year(academic_year)
-
-        expect(result).to include("last")
-      end
-    end
-
-    context "when next" do
-      before do
-        allow(academic_year).to receive(:next?).and_return(true)
-      end
-
-      it "adds next label" do
-        result = helper.display_academic_year(academic_year)
-
-        expect(result).to include("next")
+        it "adds the #{label} label" do
+          result = helper.display_academic_year(academic_year)
+          expect(result).to include(label.to_s)
+        end
       end
     end
 
@@ -100,31 +85,24 @@ RSpec.describe AcademicYearHelper, type: :helper do
         allow(academic_year).to receive(:next?).and_return(true)
       end
 
-      it "adds all applicable labels" do
+      it "adds all applicable labels in order" do
         result = helper.display_academic_year(academic_year)
-
         expect(result).to include("current")
         expect(result).to include("next")
+        expect(result).to match(%r{#{start_year} to #{end_year} - current - next})
       end
     end
   end
 
   describe "#academic_year_helper_text" do
     let(:start_year) { 2023 }
-    let(:end_year) { 2024 }
+    let(:end_year)   { 2024 }
+    let(:duration)   { Date.new(start_year, 8, 1)..Date.new(end_year, 7, 31) }
 
-    let(:duration) do
-      Date.new(start_year, 8, 1)..Date.new(end_year, 7, 31)
-    end
+    let(:academic_year) { instance_double("AcademicYear", duration:) }
 
-    let(:academic_year) do
-      instance_double("AcademicYear", duration:)
-    end
-
-    it "returns the correctly formatted academic year text" do
-      result = helper.academic_year_helper_text(academic_year)
-
-      expect(result).to eq(
+    it "returns the correctly formatted text" do
+      expect(helper.academic_year_helper_text(academic_year)).to eq(
         "Starts on 1 August #{start_year}, ends on 31 July #{end_year}"
       )
     end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe ProviderHelper, type: :helper do
         { key: { text: "Provider type" }, value: { text: provider.provider_type_label } },
         { key: { text: "Accreditation status" }, value: { text: provider.accreditation_status_label } },
         { key: { text: "Operating name" }, value: { text: provider.operating_name } },
-        { key: { text: "Legal name" }, value: { text: "Not entered", classes: "govuk-hint" } }
+        { key: { text: "Legal name" }, value: { text: "Not entered", classes: "govuk-hint" } },
+        { key: { text: "Academic years" }, value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' } },
       ])
     end
 
@@ -207,6 +208,11 @@ RSpec.describe ProviderHelper, type: :helper do
           value: { text: provider.code },
           actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
         },
+        {
+          key: { text: "Academic years" },
+          value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
+          actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
+        },
       ])
     end
 
@@ -247,6 +253,11 @@ RSpec.describe ProviderHelper, type: :helper do
             key: { text: "Provider code" },
             value: { text: provider.code },
             actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
+          },
+          {
+            key: { text: "Academic years" },
+            value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
+            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
           },
         ])
       end

--- a/spec/requests/api/v0/get_providers_spec.rb
+++ b/spec/requests/api/v0/get_providers_spec.rb
@@ -26,7 +26,14 @@ RSpec.describe "`GET /providers` endpoint", type: :request do
       create(:provider, :accredited, academic_years:)
       create(:provider, :accredited, updated_at: 3.days.ago)
 
-      latest_providers = [:school, :scitt, :hei, :hei_without_accreditation, :other, :other_without_accreditation].map do |trait|
+      latest_providers = [
+        :hei_without_accreditation,
+        :hei,
+        :other_without_accreditation,
+        :other,
+        :school,
+        :scitt,
+      ].map do |trait|
         create(:provider, trait)
       end
 


### PR DESCRIPTION
### Context
Provider summary card

### Changes proposed in this pull request
On the providers listing page it is now displaying the academic years that the provider is active in, it has a collapsed details once there is more then most recent 3 academic years 

On the provider detail page it is now displaying the academic years that the provider is active in, all details are shown.
### Guidance to review


### Before
#### Providers listing page

<img width="1668" height="1355" alt="image" src="https://github.com/user-attachments/assets/b78617b2-54fb-492f-9374-73a7cedd2299" />

<img width="620" height="336" alt="image" src="https://github.com/user-attachments/assets/758c8c48-3ee8-45d4-8d98-6aad408ad866" />

#### Provider detail page
<img width="1668" height="1355" alt="image" src="https://github.com/user-attachments/assets/5e395882-b844-4624-a982-31b5426b04f1" />

### After

#### Providers listing page
<img width="1668" height="1355" alt="image" src="https://github.com/user-attachments/assets/60c0488a-5e61-46ba-bd00-a2181d107b0b" />

<img width="620" height="490" alt="image" src="https://github.com/user-attachments/assets/a6adbb36-4229-4250-92d7-17d33adbe230" />

#### Provider detail page
<img width="1668" height="1355" alt="image" src="https://github.com/user-attachments/assets/8dfebe71-9261-4266-bef4-45a964157eeb" />