### PR TITLE
[0439] Add academic year on the search filter

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -14,6 +14,8 @@ class ProvidersController < ApplicationController
 
     provider_query = ProvidersQuery.call(filters: provider_filters, search_term: keywords)
     @pagy, @records = pagy(provider_query.order_by_operating_name, limit: 10)
+
+    @academic_years = AcademicYear.next_and_older
   end
 
   def show
@@ -66,6 +68,7 @@ private
         provider_types: [],
         accreditation_statuses: [],
         show_archived: [],
+        show_academic_years: [],
         show_seed_data: []
       ).to_h.with_indifferent_access
 

--- a/app/helpers/academic_year_helper.rb
+++ b/app/helpers/academic_year_helper.rb
@@ -44,4 +44,10 @@ module AcademicYearHelper
   def academic_year_helper_text(academic_year)
     "Starts on 1 August #{academic_year.start_year}, ends on 31 July #{academic_year.end_year}"
   end
+
+  def academic_years_label(academic_years)
+    academic_years.index_by(&:start_year)
+      .transform_values { |academic_year| display_academic_year(academic_year) }
+      .stringify_keys
+  end
 end

--- a/app/helpers/academic_year_helper.rb
+++ b/app/helpers/academic_year_helper.rb
@@ -33,12 +33,15 @@ module AcademicYearHelper
   end
 
   def display_academic_year(academic_year)
-    base = "#{academic_year.duration.begin.year} to #{academic_year.duration.end.year}"
-    labels = %i[current last next].select { |l| academic_year.public_send("#{l}?") }
-    labels.empty? ? base : "#{base} - #{labels.join(' - ')}"
+    academic_year_text = "#{academic_year.start_year} to #{academic_year.end_year}"
+    [:current, :last, :next].each do |label|
+      academic_year_text += " - #{label}" if academic_year.send(:"#{label}?")
+    end
+
+    academic_year_text
   end
 
   def academic_year_helper_text(academic_year)
-    "Starts on 1 August #{academic_year.duration.begin.year}, ends on 31 July #{academic_year.duration.end.year}"
+    "Starts on 1 August #{academic_year.start_year}, ends on 31 July #{academic_year.end_year}"
   end
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -20,6 +20,12 @@ class AcademicYear < ApplicationRecord
   has_many :provider_academic_years, dependent: :destroy
   has_many :providers, through: :provider_academic_years
 
+  scope :for_specific_years, ->(years) {
+    dates = Array(years).map { |yr| start_date_for(yr) }
+
+    covering_dates(dates).order(duration: :desc)
+  }
+
   def current?
     duration.cover?(Time.zone.today)
   end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -20,6 +20,16 @@ class AcademicYear < ApplicationRecord
   has_many :provider_academic_years, dependent: :destroy
   has_many :providers, through: :provider_academic_years
 
+  scope :next_and_older, -> {
+    cutoff_year = AcademicYearCalculator.next_academic_year + 1
+    cutoff_date = start_date_for(cutoff_year)
+
+    where(
+      "duration && daterange(NULL, ?, '[)')",
+      cutoff_date
+    ).order(duration: :desc)
+  }
+
   scope :for_specific_years, ->(years) {
     dates = Array(years).map { |yr| start_date_for(yr) }
 

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -32,8 +32,12 @@ class AcademicYear < ApplicationRecord
     duration.include?(Time.zone.today - 1.year)
   end
 
+  def self.start_date_for(year)
+    Date.new(year, 8, 1)
+  end
+
   def self.for_year(year)
-    start_date = Date.new(year, 8, 1)
+    start_date = start_date_for(year)
     where("duration @> ?::date", start_date).first
   end
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -32,6 +32,14 @@ class AcademicYear < ApplicationRecord
     duration.include?(Time.zone.today - 1.year)
   end
 
+  def start_year
+    duration.begin.year
+  end
+
+  def end_year
+    duration.end.year
+  end
+
   def self.start_date_for(year)
     Date.new(year, 8, 1)
   end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -44,8 +44,15 @@ class AcademicYear < ApplicationRecord
     Date.new(year, 8, 1)
   end
 
+  def self.covering_dates(dates)
+    dates = Array(dates)
+    return none if dates.blank?
+
+    where("duration @> ANY (ARRAY[?]::date[])", dates)
+  end
+
   def self.for_year(year)
     start_date = start_date_for(year)
-    where("duration @> ?::date", start_date).first
+    covering_dates(start_date).first
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -55,6 +55,16 @@ class Provider < ApplicationRecord
   include AccreditationStatusEnum
 
   scope :order_by_operating_name, -> { order(:operating_name) }
+  scope :for_academic_years, ->(years) {
+    years = Array(years)
+    return none if years.empty?
+
+    where(
+      id: joins(:academic_years)
+            .merge(AcademicYear.for_specific_years(years))
+            .select(:id)
+    )
+  }
 
   validates :provider_type, presence: true, provider_type: true
 

--- a/app/queries/providers_query.rb
+++ b/app/queries/providers_query.rb
@@ -22,6 +22,7 @@ class ProvidersQuery
     scope = filter_by_provider_type(relation)
     scope = filter_by_accreditation_status(scope)
     scope = filter_by_archived(scope)
+    scope = filter_by_academic_years(scope)
     scope = filter_by_seed_data(scope)
 
     scope = scope.search(search_term) if search_term.present?
@@ -75,6 +76,13 @@ private
 
   def filter_by_archived(scope)
     Array(filters[:show_archived]).include?("show_archived_provider") ? scope : scope.where(archived_at: nil)
+  end
+
+  def filter_by_academic_years(scope)
+    academic_years = Array(filters[:show_academic_years]).map(&:to_i)
+    return scope if academic_years.empty?
+
+    scope.for_academic_years(academic_years)
   end
 
   def filter_by_seed_data(scope)

--- a/app/views/providers/_filters.html.erb
+++ b/app/views/providers/_filters.html.erb
@@ -35,6 +35,14 @@
                    } %>
 
         <%= render "selected_filter_list",
+                   title: "Academic year",
+                   values: provider_filters[:show_academic_years],
+                   labels: academic_years_label(@academic_years),
+                   remove_path: ->(academic_year) {
+                     providers_path_filters_without(:show_academic_years, academic_year)
+                   } %>
+
+        <%= render "selected_filter_list",
                    title: "Archived providers",
                    values: provider_filters[:show_archived],
                    labels: t("show_archived_labels"),
@@ -71,11 +79,17 @@
           <% end %>
         <% end %>
 
+        <%= f.govuk_check_boxes_fieldset :show_academic_years, small: true, legend: { text: "Academic year", size: "s" } do %>
+          <% @academic_years.each do |academic_year| %>
+            <%= f.govuk_check_box :show_academic_years, academic_year.start_year, label: { text: display_academic_year(academic_year) }, checked: filter_checked?(:show_academic_years, academic_year.start_year) %>
+          <% end %>
+        <% end %>
+
         <%= f.govuk_check_boxes_fieldset :show_archived, small: true, legend: { text: "Archived providers", size: "s" } do %>
           <%= f.govuk_check_box :show_archived, "show_archived_provider", label: { text: "Include archived providers" }, checked: filter_checked?(:show_archived, "show_archived_provider") %>
         <% end %>
 
-        <%= f.govuk_check_boxes_fieldset :show_archived, small: true, legend: { text: "Seed data", size: "s" } do %>
+        <%= f.govuk_check_boxes_fieldset :show_seed_data, small: true, legend: { text: "Seed data", size: "s" } do %>
           <%= f.govuk_check_box :show_seed_data, "show_seed_data_with_issues", label: { text: t("show_seed_data_labels.show_seed_data_with_issues") }, checked: filter_checked?(:show_seed_data, "show_seed_data_with_issues") %>
         <% end if debug_mode? %>
       <% end %>

--- a/app/views/providers/_selected_filter_list.html.erb
+++ b/app/views/providers/_selected_filter_list.html.erb
@@ -8,7 +8,7 @@
               class: "app-filter__tag"
             ) do %>
           <span class="govuk-visually-hidden">Remove this filter</span>
-          <%= labels[val.to_sym] || val.humanize %>
+          <%= labels.with_indifferent_access.fetch(val) %>
         <% end %>
       </li>
     <% end %>

--- a/lib/academic_year_calculator.rb
+++ b/lib/academic_year_calculator.rb
@@ -1,6 +1,6 @@
 module AcademicYearCalculator
   def current_academic_year
-    Time.zone.now.month >= 8 ? Time.zone.now.year : Time.zone.now.year - 1
+    Time.zone.today.month >= 8 ? Time.zone.today.year : Time.zone.today.year - 1
   end
 
   def next_academic_year

--- a/spec/features/end_to_end/providers/filtering_providers_spec.rb
+++ b/spec/features/end_to_end/providers/filtering_providers_spec.rb
@@ -17,6 +17,12 @@ RSpec.feature "Filter Training Providers" do
     then_the_list_of_providers_should_include_archived_providers
   end
 
+  scenario "User filters providers by academic year" do
+    given_i_am_on_the_provider_list_page
+    when_i_check_the_box_for_previous_academic_year
+    then_the_list_of_providers_should_only_previous_academic_year_providers
+  end
+
   scenario "User filters providers by seed data provider issues" do
     given_i_am_on_the_provider_list_page(debug: true)
     when_i_check_the_box_for_show_seed_data_with_issues_issues
@@ -53,8 +59,23 @@ RSpec.feature "Filter Training Providers" do
     )
   end
 
+  def then_the_list_of_providers_should_only_previous_academic_year_providers
+    expect(page).to have_title("Providers (3)")
+    expect(page).to have_css(".govuk-summary-card", count: previous_academic_year_providers.count)
+
+    previous_academic_year_providers.each do |provider|
+      expect(page).to have_selector("h2", text: provider.operating_name)
+    end
+  end
+
   def when_i_check_the_box_for_accredited
     check "Accredited"
+    click_on "Apply filters"
+  end
+
+  def when_i_check_the_box_for_previous_academic_year
+    academic_year_text = "#{previous_academic_year.start_year} to #{previous_academic_year.end_year} - last"
+    check academic_year_text
     click_on "Apply filters"
   end
 
@@ -84,11 +105,24 @@ RSpec.feature "Filter Training Providers" do
     expect(page).to have_title("Providers (#{Provider.count})")
   end
 
+  def previous_academic_year
+    @previous_academic_year ||= create(:academic_year, :previous)
+  end
+
+  def previous_academic_year_providers
+    @previous_academic_year_providers ||= [
+      create(:provider, :other, :accredited, academic_years: [previous_academic_year]),
+      create(:provider, :school, academic_years: [previous_academic_year]),
+      create(:provider, :scitt, :accredited, academic_years: [previous_academic_year])
+    ]
+  end
+
   def and_there_are_a_number_of_providers
     hei_providers
     create_list(:provider, 5, :other, :accredited)
     create_list(:provider, 5, :school)
     create_list(:provider, 5, :scitt, :accredited)
+    previous_academic_year_providers
     archived_providers
   end
 

--- a/spec/helpers/academic_year_helper_spec.rb
+++ b/spec/helpers/academic_year_helper_spec.rb
@@ -96,8 +96,18 @@ RSpec.describe AcademicYearHelper, type: :helper do
   end
 
   describe "#display_academic_year" do
+    let(:start_year) { 2023 }
+    let(:end_year) { 2024 }
+
     let(:academic_year) do
-      build(:academic_year, academic_year: 2023)
+      instance_double(
+        "AcademicYear",
+        start_year: start_year,
+        end_year: end_year,
+        current?: false,
+        last?: false,
+        next?: false
+      )
     end
 
     it "formats year range correctly" do
@@ -122,13 +132,19 @@ RSpec.describe AcademicYearHelper, type: :helper do
   end
 
   describe "#academic_year_helper_text" do
+    let(:start_year) { 2023 }
+    let(:end_year) { 2024 }
+
     let(:academic_year) do
-      build(:academic_year, academic_year: 2023)
+      instance_double("AcademicYear", start_year:, end_year:,)
     end
 
-    it "formats helper text correctly" do
-      expect(helper.academic_year_helper_text(academic_year))
-        .to eq("Starts on 1 August 2023, ends on 31 July 2024")
+    it "returns the correctly formatted academic year text" do
+      result = helper.academic_year_helper_text(academic_year)
+
+      expect(result).to eq(
+        "Starts on 1 August #{start_year}, ends on 31 July #{end_year}"
+      )
     end
   end
 end

--- a/spec/helpers/academic_year_helper_spec.rb
+++ b/spec/helpers/academic_year_helper_spec.rb
@@ -1,45 +1,31 @@
 require "rails_helper"
 
 RSpec.describe AcademicYearHelper, type: :helper do
-  def build_years(count)
-    base = AcademicYearCalculator.current_academic_year
-
-    (0...count).map do |i|
-      build(:academic_year, academic_year: base - i)
-    end
-  end
-
   describe "#academic_years_row" do
+    subject { helper.academic_years_row(academic_years, false) }
+
     let(:academic_years) do
       [
-        build(:academic_year, :previous),
-        build(:academic_year, :current)
+        create(:academic_year, :current),
+        create(:academic_year, :previous)
       ]
     end
 
-    it "returns key/value structure" do
-      result = helper.academic_years_row(academic_years, false)
-
-      expect(result.keys).to contain_exactly(:key, :value)
-      expect(result[:key][:text]).to eq("Academic years")
+    it "returns a hash with key and value" do
+      expect(subject).to include(:key, :value)
+      expect(subject[:key][:text]).to eq("Academic years")
     end
 
-    it "renders a bullet list when use_details is false" do
-      result = helper.academic_years_row(academic_years, false)
-      html = result[:value][:text]
-
-      expect(html).to include("govuk-list", "govuk-list--bullet")
-      expect(html).to include("<ul")
-      expect(html).to include("<li")
+    it "renders a GOV.UK bullet list" do
+      html = Nokogiri::HTML.fragment(subject[:value][:text])
+      expect(html.css("ul.govuk-list--bullet")).to be_present
+      expect(html.css("li").count).to eq(academic_years.size)
     end
 
-    it "renders all academic years in output" do
-      result = helper.academic_years_row(academic_years, false)
-      html = result[:value][:text]
-
-      academic_years.each do |year|
-        expect(html).to include(year.duration.begin.year.to_s)
-        expect(html).to include(year.duration.end.year.to_s)
+    it "includes each academic year formatted text" do
+      binding.break
+      academic_years.each do |ay|
+        expect(subject[:value][:text]).to include("#{ay.start_year} to #{ay.end_year}")
       end
     end
   end
@@ -51,99 +37,91 @@ RSpec.describe AcademicYearHelper, type: :helper do
     end
 
     it "renders a single list when 3 or fewer items" do
-      html = helper.academic_years_html(build_years(3), true)
+      years = [
+        create(:academic_year, :current),
+        create(:academic_year, :previous)
+      ]
+
+      html = helper.academic_years_html(years, true)
 
       expect(html.scan("<ul").size).to eq(1)
       expect(html).not_to include("More academic years")
     end
 
     it "splits into primary list and details when more than 3 items" do
-      html = helper.academic_years_html(build_years(6), true)
+      years = create_list(:academic_year, 5, :previous)
+
+      html = helper.academic_years_html(years, true)
 
       expect(html.scan("<ul").size).to eq(2)
       expect(html).to include("More academic years")
-      expect(html).to include("<details")
-    end
-  end
-
-  describe "grouping behaviour (slice of 3)" do
-    it "keeps first 3 items in primary list and rest in details" do
-      years = build_years(8)
-
-      html = helper.academic_years_html(years, true)
-
-      primary = years.first(3)
-      overflow = years.drop(3)
-
-      primary.each do |year|
-        expect(html).to include(year.duration.begin.year.to_s)
-      end
-
-      overflow.each do |year|
-        expect(html).to include(year.duration.begin.year.to_s)
-      end
-    end
-
-    it "does not drop any academic years during grouping" do
-      years = build_years(8)
-
-      html = helper.academic_years_html(years, true)
 
       years.each do |year|
-        expect(html).to include(year.duration.begin.year.to_s)
+        expect(html).to include("#{year.start_year} to #{year.end_year}")
       end
     end
   end
 
   describe "#display_academic_year" do
-    let(:start_year) { 2023 }
-    let(:end_year) { 2024 }
+    subject(:result) { helper.display_academic_year(academic_year) }
 
-    let(:academic_year) do
-      instance_double(
-        "AcademicYear",
-        start_year: start_year,
-        end_year: end_year,
-        current?: false,
-        last?: false,
-        next?: false
-      )
+    let(:academic_year) { create(:academic_year, academic_year: AcademicYearCalculator.previous_academic_year - 1) }
+
+    it "formats the academic year range" do
+      expect(subject).to eq("#{academic_year.start_year} to #{academic_year.end_year}")
     end
 
-    it "formats year range correctly" do
-      expect(helper.display_academic_year(academic_year))
-        .to include("2023 to 2024")
+    context "when current" do
+      let(:academic_year) { create(:academic_year, :current) }
+
+      it "adds current label" do
+        expect(subject).to include("current")
+      end
     end
 
-    it "adds label when present" do
-      allow(academic_year).to receive(:next?).and_return(true)
+    context "when next" do
+      let(:academic_year) { create(:academic_year, :next) }
 
-      expect(helper.display_academic_year(academic_year))
-        .to include("next")
+      it "adds next label" do
+        expect(subject).to include("next")
+      end
     end
 
-    it "orders multiple labels correctly" do
-      allow(academic_year).to receive(:current?).and_return(true)
-      allow(academic_year).to receive(:next?).and_return(true)
+    context "when previous (last)" do
+      let(:academic_year) { create(:academic_year, :previous) }
 
-      expect(helper.display_academic_year(academic_year))
-        .to eq("2023 to 2024 - current - next")
+      it "adds last label" do
+        expect(subject).to include("last")
+      end
     end
   end
 
   describe "#academic_year_helper_text" do
-    let(:start_year) { 2023 }
-    let(:end_year) { 2024 }
+    subject { helper.academic_year_helper_text(academic_year) }
 
-    let(:academic_year) do
-      instance_double("AcademicYear", start_year:, end_year:,)
+    let(:academic_year) { create(:academic_year, :current) }
+
+    it "formats academic year helper text correctly" do
+      expect(subject).to eq("Starts on 1 August #{academic_year.start_year}, ends on 31 July #{academic_year.end_year}")
     end
+  end
 
-    it "returns the correctly formatted academic year text" do
-      result = helper.academic_year_helper_text(academic_year)
+  describe "#academic_years_label" do
+    subject { helper.academic_years_label(academic_years) }
 
-      expect(result).to eq(
-        "Starts on 1 August #{start_year}, ends on 31 July #{end_year}"
+    let(:current_year) { create(:academic_year, :current) }
+    let(:next_year) { create(:academic_year, :next) }
+    let(:previous_year) { create(:academic_year, :previous) }
+    let(:other_year) { create(:academic_year, academic_year: AcademicYearCalculator.previous_academic_year - 1) }
+
+    let(:academic_years) { [current_year, next_year, previous_year, other_year] }
+
+    it "returns a hash indexed by start_year with formatted values" do
+      expect(subject).to match(
+        current_year.start_year.to_s => "#{current_year.start_year} to #{current_year.end_year} - current",
+        next_year.start_year.to_s => "#{next_year.start_year} to #{next_year.end_year} - next",
+        previous_year.start_year.to_s => "#{previous_year.start_year} to #{previous_year.end_year} - last",
+        other_year.start_year.to_s => "#{other_year.start_year} to #{other_year.end_year}"
       )
     end
   end

--- a/spec/helpers/academic_year_helper_spec.rb
+++ b/spec/helpers/academic_year_helper_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe AcademicYearHelper, type: :helper do
     end
 
     it "includes each academic year formatted text" do
-      binding.break
       academic_years.each do |ay|
         expect(subject[:value][:text]).to include("#{ay.start_year} to #{ay.end_year}")
       end

--- a/spec/lib/academic_year_calculator_spec.rb
+++ b/spec/lib/academic_year_calculator_spec.rb
@@ -1,38 +1,45 @@
-# spec/helpers/academic_year_helper_spec.rb
+# spec/helpers/academic_year_calculator_spec.rb
 require "rails_helper"
 
 RSpec.describe AcademicYearCalculator do
-  describe ".current_academic_year" do
-    context "when month is August or later" do
-      it "returns the current year" do
-        Timecop.freeze(Time.zone.local(2025, 8, 1)) do
-          expect(described_class.current_academic_year).to eq(2025)
-        end
-      end
+  around do |example|
+    Timecop.freeze(Time.zone.local(2025, 9, 1)) do
+      example.run
     end
+  end
 
-    context "when month is before August" do
-      it "returns the previous year" do
-        Timecop.freeze(Time.zone.local(2025, 7, 31)) do
-          expect(described_class.current_academic_year).to eq(2024)
+  describe ".current_academic_year" do
+    it "returns 2025 for September 2025" do
+      expect(described_class.current_academic_year).to eq(2025)
+    end
+  end
+
+  describe ".month boundary behaviour" do
+    it "shifts academic year correctly before and after August" do
+      travel_cases = [
+        [Time.zone.local(2025, 7, 31), 2024],
+        [Time.zone.local(2025, 8, 1), 2025]
+      ]
+
+      travel_cases.each do |date, expected|
+        Timecop.freeze(date) do
+          expect(described_class.current_academic_year).to eq(expected)
         end
       end
     end
   end
 
   describe ".next_academic_year" do
-    it "returns the next academic year" do
-      Timecop.freeze(Time.zone.local(2025, 9, 1)) do
-        expect(described_class.next_academic_year).to eq(2026)
-      end
+    it "is current + 1" do
+      expect(described_class.next_academic_year)
+        .to eq(described_class.current_academic_year + 1)
     end
   end
 
   describe ".previous_academic_year" do
-    it "returns the previous academic year" do
-      Timecop.freeze(Time.zone.local(2025, 9, 1)) do
-        expect(described_class.previous_academic_year).to eq(2024)
-      end
+    it "is current - 1" do
+      expect(described_class.previous_academic_year)
+        .to eq(described_class.current_academic_year - 1)
     end
   end
 end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -96,4 +96,30 @@ RSpec.describe AcademicYear, type: :model do
         .to eq(Date.new(2025, 8, 1))
     end
   end
+
+  describe ".covering_dates" do
+    let!(:current_year) { create(:academic_year, :current) }
+    let!(:previous_year) { create(:academic_year, :previous) }
+
+    it "returns academic years covering a given date" do
+      result = described_class.covering_dates(current_year.duration.begin,)
+
+      expect(result).to contain_exactly(current_year)
+    end
+
+    it "returns multiple academic years when multiple dates match" do
+      dates = [
+        current_year.duration.begin,
+        previous_year.duration.begin,
+      ]
+
+      result = described_class.covering_dates(dates)
+
+      expect(result).to contain_exactly(current_year, previous_year)
+    end
+
+    it "returns none when given empty input" do
+      expect(described_class.covering_dates([])).to be_empty
+    end
+  end
 end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -97,6 +97,28 @@ RSpec.describe AcademicYear, type: :model do
     end
   end
 
+  describe ".next_and_older" do
+    let!(:current_year) { create(:academic_year, :current) }
+    let!(:previous_year) { create(:academic_year, :previous) }
+    let!(:next_year) { create(:academic_year, :next) }
+    let!(:far_future_year) { create(:academic_year, academic_year: AcademicYearCalculator.next_academic_year + 1) }
+
+    it "includes the next academic year (today + 1.year) and all older years" do
+      result = described_class.next_and_older.to_a
+      expect(result).to include(previous_year)
+      expect(result).to include(current_year)
+      expect(result).to include(next_year)
+      expect(result).not_to include(far_future_year)
+    end
+
+    it "orders by the implicit order column (duration: :desc)" do
+      ordered = described_class.next_and_older.pluck(:id)
+      expected = [next_year, current_year, previous_year].map(&:id)
+
+      expect(ordered).to eq(expected)
+    end
+  end
+
   describe ".covering_dates" do
     let!(:current_year) { create(:academic_year, :current) }
     let!(:previous_year) { create(:academic_year, :previous) }

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -80,4 +80,20 @@ RSpec.describe AcademicYear, type: :model do
       end
     end
   end
+
+  describe "#start_year and #end_year" do
+    it "returns the correct start and end years" do
+      ay = create(:academic_year, academic_year: 2025)
+
+      expect(ay.start_year).to eq(2025)
+      expect(ay.end_year).to eq(2026)
+    end
+  end
+
+  describe ".start_date_for" do
+    it "returns August 1 of the given year" do
+      expect(described_class.start_date_for(2025))
+        .to eq(Date.new(2025, 8, 1))
+    end
+  end
 end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AcademicYear, type: :model do
     end
   end
 
-  describe "#last??" do
+  describe "#last?" do
     context "when it is the next academic_year" do
       it "is expected to be true" do
         Timecop.travel(AcademicYearCalculator.next_academic_year, 9, 1) do

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -122,4 +122,32 @@ RSpec.describe AcademicYear, type: :model do
       expect(described_class.covering_dates([])).to be_empty
     end
   end
+
+  describe ".for_specific_years" do
+    let!(:current_year) { create(:academic_year, :current) }
+    let!(:previous_year) { create(:academic_year, :previous) }
+    let!(:next_year) { create(:academic_year, :next) }
+
+    it "returns matching academic years for given years" do
+      result = described_class.for_specific_years([previous_year.start_year, next_year.start_year])
+
+      expect(result).to contain_exactly(previous_year, next_year)
+    end
+
+    it "orders results by duration descending" do
+      result = described_class.for_specific_years([previous_year.start_year, current_year.start_year, next_year.start_year])
+
+      expect(result).to eq([next_year, current_year, previous_year])
+    end
+
+    it "returns empty when no matches" do
+      expect(described_class.for_specific_years([AcademicYearCalculator.previous_academic_year - 1])).to be_empty
+    end
+
+    it "handles single year input" do
+      result = described_class.for_specific_years(current_year.start_year)
+
+      expect(result).to contain_exactly(current_year)
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -242,6 +242,64 @@ RSpec.describe Provider, type: :model do
     end
   end
 
+  describe ".for_academic_years" do
+    let!(:current_year)  { create(:academic_year, :current) }
+    let!(:previous_year) { create(:academic_year, :previous) }
+    let!(:next_year)     { create(:academic_year, :next) }
+
+    let!(:provider_current_only) do
+      create(:provider, academic_years: [current_year])
+    end
+
+    let!(:provider_multiple_years) do
+      create(:provider, academic_years: [current_year, previous_year])
+    end
+
+    let!(:provider_other_year) do
+      create(:provider, academic_years: [next_year])
+    end
+
+    it "returns providers that match ANY of the given academic years" do
+      result = described_class.for_academic_years([current_year.start_year])
+
+      expect(result).to contain_exactly(
+        provider_current_only,
+        provider_multiple_years
+      )
+    end
+
+    it "returns providers matching multiple years" do
+      result = described_class.for_academic_years([
+        current_year.start_year,
+        previous_year.start_year
+      ])
+
+      expect(result).to contain_exactly(
+        provider_current_only,
+        provider_multiple_years
+      )
+    end
+
+    it "does not include providers that do not match any given years" do
+      result = described_class.for_academic_years([current_year.start_year])
+
+      expect(result).not_to include(provider_other_year)
+    end
+
+    it "does not return duplicates when a provider matches multiple years" do
+      result = described_class.for_academic_years([
+        current_year.start_year,
+        previous_year.start_year
+      ])
+
+      expect(result.where(id: provider_multiple_years.id).count).to eq(1)
+    end
+
+    it "returns none when years are empty" do
+      expect(described_class.for_academic_years([])).to be_empty
+    end
+  end
+
   describe ".search" do
     let!(:provider_alpha) { create(:provider, operating_name: "Alpha Teaching Trust", urn: "123456", ukprn: "78901234") }
     let!(:provider_bravo) { create(:provider, operating_name: "Bravo Academy", urn: "654321", ukprn: "43210987") }

--- a/spec/queries/providers_query_spec.rb
+++ b/spec/queries/providers_query_spec.rb
@@ -198,4 +198,27 @@ RSpec.describe ProvidersQuery do
       expect(results).to contain_exactly(scitt_accredited)
     end
   end
+
+  describe "academic year filtering" do
+    let(:current_academic_year) { build(:academic_year, :current) }
+    let(:next_academic_year) { build(:academic_year, :next) }
+    let(:previous_academic_year) { build(:academic_year, :previous) }
+
+    let!(:current_provider) { create(:provider) }
+    let!(:multi_academic_years_provider) do
+      create(:provider, academic_years: [current_academic_year,
+                                         next_academic_year,
+                                         previous_academic_year])
+    end
+    let!(:other_provider) do
+      create(:provider, academic_years: [next_academic_year,
+                                         previous_academic_year])
+    end
+
+    let(:filters) { { show_academic_years: [AcademicYearCalculator.current_academic_year] } }
+
+    it "filters providers by academic years" do
+      expect(results).to contain_exactly(current_provider, multi_academic_years_provider)
+    end
+  end
 end

--- a/spec/views/provider/index.html.erb_spec.rb
+++ b/spec/views/provider/index.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "providers/index.html.erb", type: :view do
   let(:providers) { [provider_1, provider_2, provider_3] }
   let(:count) { providers.size }
   let(:pagy) { Pagy.new(count: count, page: 1) }
+  let(:academic_years) { build_stubbed_list(:academic_year, 3) }
 
   let(:pagination_component) { instance_double(PaginationDisplay::View) }
 
@@ -15,6 +16,7 @@ RSpec.describe "providers/index.html.erb", type: :view do
   before do
     assign(:records, providers)
     assign(:pagy, pagy)
+    assign(:academic_years, academic_years)
     allow(view).to receive(:page_data)
     def view.provider_filters
       {}

--- a/test/factories/academic_years.rb
+++ b/test/factories/academic_years.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :academic_year do
     current
     duration do
-      Date.new(academic_year, 8, 1)..Date.new(academic_year + 1, 7, 31)
+      Date.new(academic_year, 8, 1)...Date.new(academic_year + 1, 8, 1)
     end
 
     initialize_with do


### PR DESCRIPTION
### Context
Finding providers with a specified academic year on the search filter

### Changes proposed in this pull request
Added academic year on the search filter

### Guidance to review
The filters works as additive/or manner when more then one academic year is selected.
Provider needs to be in at least one not all.

#### Before
<img width="1668" height="6065" alt="image" src="https://github.com/user-attachments/assets/317076bc-e8ea-4666-83d1-b48782f50d1e" />


#### After
<img width="1668" height="6105" alt="image" src="https://github.com/user-attachments/assets/fc3a968c-124c-458b-8c71-5f09b06c4549" />

<img width="1668" height="6105" alt="image" src="https://github.com/user-attachments/assets/82bf236d-747c-4374-9cba-46ce6162ee1a" />

