### PR TITLE
[410] - Revoke all API clients for inactive user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,8 @@ class User < ApplicationRecord
 
   scope :order_by_first_then_last_name, -> { order(:first_name, :last_name) }
 
+  after_save :revoke_all_active_tokens_for_api_clients!, unless: :active?
+
   def name
     first_name_to_use = first_name_was || first_name
     last_name_to_use = last_name_was || last_name
@@ -80,5 +82,9 @@ private
 
   def sanitise_email
     self.email = email.gsub(/\s+/, "").downcase unless email.nil?
+  end
+
+  def revoke_all_active_tokens_for_api_clients!
+    api_clients.kept.find_each(&:revoke_all_active_tokens!)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -247,5 +247,21 @@ RSpec.describe User, type: :model do
     it "is true by default" do
       expect(user.active?).to be true
     end
+
+    context "user has api clients" do
+      let(:api_client) { create(:api_client, :with_authentication_token, created_by: user) }
+
+      it "revokes all active tokens for api clients when set to false" do
+        expect {
+          user.update!(active: false)
+        }.to change { api_client.authentication_tokens.first.reload.status }.from("active").to("revoked")
+      end
+
+      it "does not revoke active tokens for other attribute changes" do
+        expect {
+          user.update!(first_name: "Jeff")
+        }.not_to change { api_client.authentication_tokens.first.reload.status }.from("active")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/nJD2RpZz/410-revoke-all-api-clients-for-inactive-user

### Changes proposed in this pull request

Revokes all active tokens for user's api clients when they become inactive.

### Guidance to review
