### PR TITLE
[411] - Inactive API client access prevention

### DIFF
--- a/spec/requests/api/v0/get_info_spec.rb
+++ b/spec/requests/api/v0/get_info_spec.rb
@@ -6,17 +6,41 @@ RSpec.describe "`GET /info` endpoint", type: :request do
   it_behaves_like "a register API endpoint", "/api/#{version}/info"
 
   context "response content" do
-    let(:auth_token) { create(:authentication_token) }
+    let(:auth_token) { create(:authentication_token, status:) }
     let(:token) { auth_token.token }
 
-    it "returns the requested and latest API version and status", openapi: { summary: "Provides general information about the API", tags: ["Info"] } do
-      get "/api/#{version}/info", headers: { Authorization: token }
+    context "with an active token" do
+      let(:status) { :active }
 
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq(
-        "status" => "ok",
-        "version" => { "latest" => "v0", "requested" => "v0" }
-      )
+      it "returns the requested and latest API version and status", openapi: { summary: "Provides general information about the API", tags: ["Info"] } do
+        get "/api/#{version}/info", headers: { Authorization: token }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq(
+          "status" => "ok",
+          "version" => { "latest" => "v0", "requested" => "v0" }
+        )
+      end
+    end
+
+    context "with a revoked token" do
+      let(:status) { :revoked }
+
+      it "returns unauthorised" do
+        get "/api/#{version}/info", headers: { Authorization: token }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with an expired token" do
+      let(:status) { :expired }
+
+      it "returns unauthorised" do
+        get "/api/#{version}/info", headers: { Authorization: token }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/d4aJZtH3/411-inactive-api-client-access-prevention

### Changes proposed in this pull request

Add specs to for revoked and expired tokens

### Guidance to review
