### PR TITLE
[0328] Create schema for endpoints

### DIFF
--- a/app/controllers/api_docs/pages_controller.rb
+++ b/app/controllers/api_docs/pages_controller.rb
@@ -5,10 +5,8 @@ module ApiDocs
     end
 
     def show
-      doc = params[:doc]
-
       @endpoint = ApiDocs::ApiDocPresenter.new(
-        spec: @spec = ApiDocs::OpenapiSpecification.endpoints["/#{doc}"],
+        doc: params[:doc],
         method: params[:method]
       )
     end

--- a/app/helpers/api_docs_helper.rb
+++ b/app/helpers/api_docs_helper.rb
@@ -9,4 +9,30 @@ module ApiDocsHelper
       doc:
     )
   end
+
+  def schema_description(value, row_data)
+    descriptions = [value.to_s]
+    if row_data[:enum].present?
+      descriptions << "<br>".html_safe
+      descriptions << "<br>".html_safe
+      descriptions << "Possible values:"
+      descriptions << content_tag(:ul, class: "govuk-list govuk-list--bullet") do
+        row_data[:enum].map { |enum| content_tag(:li, enum) }.join.html_safe
+      end
+    end
+
+    if row_data[:format].present?
+      descriptions << "<br>".html_safe
+      descriptions << "<br>".html_safe
+      descriptions << "This field will be in the format #{row_data[:format]}."
+    end
+
+    if row_data[:nullable] == true
+      descriptions << "<br>".html_safe
+      descriptions << "<br>".html_safe
+      descriptions << "This field can also be null."
+    end
+
+    { text: safe_join(descriptions) }
+  end
 end

--- a/app/lib/api_docs/openapi_specification.rb
+++ b/app/lib/api_docs/openapi_specification.rb
@@ -30,5 +30,91 @@ module ApiDocs
     def self.has_specification?(endpoint, http_method)
       endpoints.dig("/#{endpoint}", :specifications, http_method).present?
     end
+
+    def self.endpoint_table(path, method = "get")
+      schema = endpoints.dig(
+        path,
+        :specifications,
+        method,
+        "responses",
+        "200",
+        "content",
+        "application/json",
+        "schema"
+      )
+
+      schema_to_table(schema)
+    end
+
+    def self.schema_to_table(schema, prefix = nil, required = [])
+      return [] unless schema.is_a?(Hash)
+
+      type = schema["type"]
+
+      case type
+      when "object"
+        object_to_table(schema, prefix, required)
+
+      when "array"
+        array_to_table(schema, prefix, required)
+
+      else
+        scalar_to_table(schema, prefix, required)
+      end
+    end
+
+    def self.object_to_table(schema, prefix, _required)
+      properties = schema["properties"] || {}
+      required_fields = schema["required"] || []
+
+      properties.flat_map do |key, value|
+        path = [prefix, key].compact.join(".")
+
+        schema_to_table(
+          value,
+          path,
+          required_fields
+        )
+      end
+    end
+
+    def self.array_to_table(schema, prefix, required)
+      rows = []
+
+      rows << build_row(
+        schema,
+        prefix,
+        type_override: "array",
+        required: required
+      )
+
+      items = schema["items"]
+      return rows unless items
+
+      rows + schema_to_table(items, "#{prefix}[]", required)
+    end
+
+    def self.scalar_to_table(schema, prefix, required)
+      [
+        build_row(
+          schema,
+          prefix,
+          required:
+        )
+      ]
+    end
+
+    def self.build_row(schema, prefix, required:, type_override: nil)
+      {
+        field: prefix,
+        type: type_override || schema["type"],
+        format: schema["format"],
+        required: required.include?(prefix&.split(".")&.last),
+        description: schema["description"],
+        example: schema["example"],
+        enum: schema["enum"],
+        nullable: schema["nullable"]
+      }.compact
+    end
   end
 end

--- a/app/presenters/api_docs/api_doc_presenter.rb
+++ b/app/presenters/api_docs/api_doc_presenter.rb
@@ -1,32 +1,40 @@
 module ApiDocs
   class ApiDocPresenter
-    def initialize(spec:, method:)
-      @spec = spec
+    def initialize(doc:, method:)
+      @doc = doc
       @method = method.to_sym
     end
 
+    def spec
+      @spec ||= OpenapiSpecification.endpoints[doc_path]
+    end
+
+    def schema
+      @schema ||= OpenapiSpecification.endpoint_table(doc_path, method)
+    end
+
     def heading
-      @spec[:heading]
+      @heading ||= spec[:heading]
     end
 
     def summary
-      method_spec[:summary]
+      @summary ||= method_spec[:summary]
     end
 
     def path
-      @spec[:path]
+      @path ||= spec[:path]
     end
 
     def http_method
-      @method.to_s.upcase
+      @http_method ||= method.to_s.upcase
     end
 
     def parameters
-      Array(method_spec[:parameters])
+      @parameters ||= Array(method_spec[:parameters])
     end
 
     def parameter_rows
-      parameters.map do |param|
+      @parameter_rows ||= parameters.map do |param|
         [
           param[:name].to_s,
           param[:in].to_s,
@@ -39,7 +47,7 @@ module ApiDocs
     end
 
     def responses
-      method_spec[:responses] || {}
+      @responses ||= method_spec[:responses] || {}
     end
 
     def response(status)
@@ -64,8 +72,14 @@ module ApiDocs
 
   private
 
+    attr_reader :doc, :method
+
     def method_spec
-      @spec.fetch(:specifications).fetch(@method)
+      @method_spec ||= spec.fetch(:specifications).fetch(@method)
+    end
+
+    def doc_path
+      @doc_path ||= "/#{doc}"
     end
   end
 end

--- a/app/views/api_docs/pages/show.html.erb
+++ b/app/views/api_docs/pages/show.html.erb
@@ -18,6 +18,7 @@
       <li><a class="govuk-link" href="#authentication">Authentication</a></li>
       <li><a class="govuk-link" href="#query-parameters">Query parameters</a></li>
       <li><a class="govuk-link" href="#possible-responses">Possible response</a></li>
+      <li><a class="govuk-link" href="#schema">Schema</a></li>
     </ul>
 
     <% if @endpoint.summary.present? %>
@@ -66,7 +67,8 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
+
     <h2 class="govuk-heading-l" id="possible-responses">Possible responses</h2>
       <% ["200", "401"].each do |http_code|
          if @endpoint.response(http_code).present? %>
@@ -78,5 +80,51 @@
           <% end %>
         <% end %>
       <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l" id="schema">Schema</h2>
+    <% if @endpoint.schema.present? %>
+
+      <%= govuk_table do |table|
+            table.with_head do |head|
+              head.with_row do |row|
+                ["Field", "Type", "Required", "Description", "Example"].each do |heading|
+                  options = { text: heading }
+                  options[:width] = "one-quarter" if heading == "Example"
+
+                  row.with_cell(**options)
+                end
+              end
+            end
+
+            fields = [:field,
+                      :type,
+                      :required,
+                      :description,
+                      :example]
+            table.with_body do |body|
+              @endpoint.schema.each do |row_data|
+                body.with_row do |row|
+                  fields.each_with_index do |field, index|
+                    value = row_data[field]
+                    options = if field == :description
+                                schema_description(value, row_data)
+                              else
+                                { text: value.to_s }
+                              end
+                    if index == 4 && value.present?
+                      options[:html_attributes] = { class: "app-table-example" }
+                    end
+
+                    row.with_cell(**options)
+                  end
+                end
+              end
+            end
+          end %>
+    <% end %>
   </div>
 </div>

--- a/public/openapi/v0.yaml
+++ b/public/openapi/v0.yaml
@@ -8,8 +8,6 @@ paths:
   "/api/{api_version}/info":
     get:
       summary: Provides general information about the API
-      description: This endpoint can be used to retrieve general information about
-        the API.
       tags:
       - Info
       parameters:
@@ -27,8 +25,9 @@ paths:
         schema:
           type: string
         example: v0
-        description: The API version to use in the request path. This should be set
-          to the latest version for this endpoint.
+        description: |
+          The API version to use in the request path.
+          This should be set to the latest version for this endpoint.
       responses:
         '200':
           description: returns the requested and latest API version and status
@@ -39,13 +38,19 @@ paths:
                 properties:
                   status:
                     type: string
+                    description: The status of the request.
+                    example: ok
                   version:
                     type: object
                     properties:
                       requested:
                         type: string
+                        description: The requested API version.
+                        example: v0
                       latest:
                         type: string
+                        description: The latest available API version.
+                        example: v0
                     required:
                     - requested
                     - latest
@@ -70,12 +75,11 @@ paths:
                 - error
               example:
                 error: Unauthorized
+      description: This endpoint can be used to retrieve general information about
+        the API.
   "/api/{api_version}/providers":
     get:
       summary: Get many providers
-      description: |
-        This endpoint can be used to retrieve providers for a given academic year.
-        This is intended to make it possible to check for new or updated providers regularly.
       tags:
       - providers
       parameters:
@@ -94,17 +98,19 @@ paths:
           type: integer
         example: 2025
         description: |
-          Filters providers by the specified academic year. The value
-          must be a 4-digit year, for example 2025. If not provided, the API will
-          return providers active in the current academic year.
+          Filters providers by the specified academic year.
+          The value must be a 4-digit year, for example 2025.
+
+          If not provided, the API will return providers active in the current academic year.
       - name: api_version
         in: path
         required: true
         schema:
           type: string
         example: v0
-        description: The API version to use in the request path. This should be set
-          to the latest version for this endpoint.
+        description: |
+          The API version to use in the request path.
+          This should be set to the latest version for this endpoint.
       - name: changed_since
         in: query
         required: false
@@ -129,21 +135,50 @@ paths:
                       properties:
                         id:
                           type: string
+                          description: The unique UUID identifier for the training
+                            provider.
+                          example: 7bcf4928-a0c7-4fa7-aa46-d4297eec31e0
                         operating_name:
                           type: string
+                          description: The primary business or operating name of the
+                            training provider.
+                          example: Bobby Jacob University
                         provider_type:
                           type: string
+                          description: The classification of the provider.
+                          enum:
+                          - hei
+                          - scitt
+                          - school
+                          - other
+                          example: hei
                         code:
                           type: string
+                          description: The unique 3-character identifier code for
+                            the provider.
+                          example: 1BJ
                         accreditation_status:
                           type: string
+                          description: The current accreditation status of the provider.
+                          enum:
+                          - accredited
+                          - unaccredited
+                          example: accredited
                         ukprn:
                           type: string
+                          description: The 8-digit UK Provider Reference Number.
+                          example: '77336264'
                         urn:
                           type: string
                           nullable: true
+                          description: The 6-digit Unique Reference Number for schools.
+                          example: '543380'
                         updated_at:
                           type: string
+                          description: The ISO 8601 timestamp of when the provider
+                            record was last modified.
+                          format: date-time
+                          example: '2025-09-15T11:34:56Z'
                       required:
                       - id
                       - operating_name
@@ -153,6 +188,8 @@ paths:
                       - ukprn
                       - urn
                       - updated_at
+                    description: An array of training provider objects matching the
+                      specified filters.
                 required:
                 - data
               example:
@@ -219,3 +256,6 @@ paths:
                 - error
               example:
                 error: Unauthorized
+      description: |
+        This endpoint can be used to retrieve providers for a given academic year.
+        This is intended to make it possible to check for new or updated providers regularly.

--- a/spec/helpers/api_docs_helper_spec.rb
+++ b/spec/helpers/api_docs_helper_spec.rb
@@ -57,4 +57,104 @@ RSpec.describe ApiDocsHelper, type: :helper do
       end
     end
   end
+
+  describe "#schema_description" do
+    subject(:result) { helper.schema_description(description, row_data) }
+
+    let(:description) { "A provider type." }
+    let(:row_data) { {} }
+
+    it "returns the description text" do
+      expect(result[:text].to_s).to include("A provider type.")
+    end
+
+    context "when enum values are present" do
+      let(:row_data) do
+        {
+          enum: %w[hei school scitt]
+        }
+      end
+
+      it "includes the possible values heading" do
+        expect(result[:text].to_s).to include("Possible values:")
+      end
+
+      it "includes each enum value" do
+        expect(result[:text].to_s).to include("hei")
+        expect(result[:text].to_s).to include("school")
+        expect(result[:text].to_s).to include("scitt")
+      end
+    end
+
+    context "when a format is present" do
+      let(:row_data) do
+        {
+          format: "date-time"
+        }
+      end
+
+      it "includes the format description" do
+        expect(result[:text].to_s)
+          .to include("This field will be in the format date-time.")
+      end
+    end
+
+    context "when the field is nullable" do
+      let(:row_data) do
+        {
+          nullable: true
+        }
+      end
+
+      it "includes the nullable description" do
+        expect(result[:text].to_s)
+          .to include("This field can also be null.")
+      end
+    end
+
+    context "when enum, format and nullable are all present" do
+      let(:row_data) do
+        {
+          enum: %w[accredited unaccredited],
+          format: "date-time",
+          nullable: true
+        }
+      end
+
+      it "includes all supplementary information" do
+        text = result[:text].to_s
+
+        expect(text).to include("Possible values:")
+        expect(text).to include("accredited")
+        expect(text).to include("unaccredited")
+        expect(text).to include("This field will be in the format date-time.")
+        expect(text).to include("This field can also be null.")
+      end
+    end
+
+    context "when enum is empty" do
+      let(:row_data) do
+        {
+          enum: []
+        }
+      end
+
+      it "does not include possible values" do
+        expect(result[:text].to_s).not_to include("Possible values:")
+      end
+    end
+
+    context "when nullable is false" do
+      let(:row_data) do
+        {
+          nullable: false
+        }
+      end
+
+      it "does not include the nullable message" do
+        expect(result[:text].to_s)
+          .not_to include("This field can also be null.")
+      end
+    end
+  end
 end

--- a/spec/lib/api_docs/openapi_specification_spec.rb
+++ b/spec/lib/api_docs/openapi_specification_spec.rb
@@ -1,10 +1,16 @@
-# spec/lib/api_docs/openapi_specification_spec.rb
 require "rails_helper"
-require_relative "../../../app/lib/api_docs/openapi_specification"
 
 RSpec.describe ApiDocs::OpenapiSpecification do
   describe ".specification" do
     it { expect(described_class.specification).to be_a(Hash) }
+
+    it "loads a specific versioned file when provided" do
+      expect(YAML).to receive(:load_file)
+        .with("public/openapi/v1.yaml", permitted_classes: [Time])
+        .and_return({})
+
+      described_class.specification("v1")
+    end
   end
 
   describe ".as_yaml" do
@@ -23,7 +29,6 @@ RSpec.describe ApiDocs::OpenapiSpecification do
     end
 
     it "builds a structured endpoint hash keyed by API path" do
-      expect(endpoints.keys).to contain_exactly("/info", "/providers")
       expect(endpoints["/info"].keys).to contain_exactly("specifications", "heading", "path")
       expect(endpoints["/providers"].keys).to contain_exactly("specifications", "heading", "path")
     end
@@ -40,38 +45,76 @@ RSpec.describe ApiDocs::OpenapiSpecification do
     end
   end
 
+  describe ".has_specification?" do
+    it "returns true when endpoint and method exist" do
+      expect(described_class.has_specification?("info", :get)).to eq(true)
+    end
+
+    it "returns false when endpoint is missing" do
+      expect(described_class.has_specification?("missing", :get)).to eq(false)
+    end
+
+    it "returns false when HTTP method is missing" do
+      expect(described_class.has_specification?("info", :post)).to eq(false)
+    end
+  end
+
   context "manually added descriptions" do
-    let(:openapi_data) { YAML.load_file(Rails.root.join("spec/support/openapi/post_documentation.yml")) }
+    let(:openapi_data) do
+      YAML.load_file(
+        Rails.root.join("spec/support/openapi/post_documentation.yml"),
+        aliases: true
+      )
+    end
+
     let(:spec) { described_class.specification }
+
     def find_param(path, method, param_name)
       spec.dig("paths", path, method, "parameters")&.find { |p| p["name"] == param_name }
     end
 
     def find_property(prop_name)
-      spec.dig("paths", "/api/{api_version}/providers", "get", "responses", "200", "content", "application/json", "schema", "properties", "data", "items", "properties", prop_name)
+      spec.dig(
+        "paths",
+        "/api/{api_version}/providers",
+        "get",
+        "responses",
+        "200",
+        "content",
+        "application/json",
+        "schema",
+        "properties",
+        "data",
+        "items",
+        "properties",
+        prop_name
+      )
     end
 
     context "parameters-level descriptions" do
-      it "matches the data.yml for all parameters" do
+      it "matches the post_documentation.yml for all parameters" do
         ["/api/{api_version}/info", "/api/{api_version}/providers"].each do |path|
-          openapi_data["parameters"].each do |name, description|
+          openapi_data["parameters"].each do |name, description_hash|
             param = find_param(path, "get", name)
             next unless param
 
-            expect(param["description"].squish).to eq(description.squish)
+            expect(param["description"].to_s.squish)
+              .to eq(description_hash["description"].to_s.squish)
           end
         end
       end
     end
 
     context "operation-level descriptions" do
-      it "matches the data.yml for endpoint descriptions" do
-        openapi_data["endpoints"].each do |path_key, data|
-          # Find the path in the spec that includes our key
+      it "matches the post_documentation.yml for endpoint descriptions" do
+        openapi_data["paths"].each do |path_key, data|
           full_path = spec["paths"].keys.find { |k| k.include?(path_key) }
+          next unless full_path
+
           description = spec.dig("paths", full_path, "get", "description")
 
-          expect(description.squish).to eq(data["description"].squish)
+          expect(description.to_s.squish)
+            .to eq(data["description"].to_s.squish)
         end
       end
     end
@@ -90,26 +133,33 @@ RSpec.describe ApiDocs::OpenapiSpecification do
         "data"
       )
 
-      expect(data_property["description"]).to eq(
-        openapi_data.dig(
-          "providers_properties",
-          "data",
-          "description"
-        )
+      expected = openapi_data.dig(
+        "paths",
+        "/api/{api_version}/providers",
+        "responses",
+        "200",
+        "application/json",
+        "schema",
+        "properties",
+        "data",
+        "description"
       )
+
+      expect(data_property["description"]).to eq(expected)
     end
 
     context "provider property descriptions" do
-      it "matches the data.yml for all provider properties" do
+      it "matches the post_documentation.yml for all provider properties" do
         openapi_data["provider_properties"].each do |name, data|
           property = find_property(name)
 
-          expect(property).to be_present, "Expected property '#{name}' to exist in schema"
+          expect(property).to be_present,
+                              "Expected property '#{name}' to exist in schema"
 
-          expect(property["description"].squish).to eq(data["description"].squish)
+          expect(property["description"].to_s.squish)
+            .to eq(data["description"].to_s.squish)
 
           expect(property["example"].to_s).to eq(data["example"].to_s) if data["example"]
-
           expect(property["enum"]).to eq(data["enum"]) if data["enum"]
         end
       end
@@ -122,11 +172,15 @@ RSpec.describe ApiDocs::OpenapiSpecification do
 
       expect(rows).to be_an(Array)
       expect(rows).not_to be_empty
+      expect(rows.first).to include(:field, :type)
+    end
 
-      expect(rows.first).to include(
-        :field,
-        :type
-      )
+    it "returns empty array when schema is missing" do
+      allow(described_class).to receive(:endpoints).and_return({
+        "/test" => { specifications: { get: {} } }
+      })
+
+      expect(described_class.endpoint_table("/test", :get)).to eq([])
     end
   end
 
@@ -148,9 +202,7 @@ RSpec.describe ApiDocs::OpenapiSpecification do
               "type" => "object",
               "required" => ["name"],
               "properties" => {
-                "name" => {
-                  "type" => "string"
-                }
+                "name" => { "type" => "string" }
               }
             }
           }
@@ -201,6 +253,72 @@ RSpec.describe ApiDocs::OpenapiSpecification do
       expect(described_class.schema_to_table("foo")).to eq([])
       expect(described_class.schema_to_table([])).to eq([])
     end
+
+    it "handles deeply nested objects" do
+      schema = {
+        "type" => "object",
+        "properties" => {
+          "a" => {
+            "type" => "object",
+            "properties" => {
+              "b" => {
+                "type" => "object",
+                "properties" => {
+                  "c" => {
+                    "type" => "string",
+                    "description" => "deep value"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      rows = described_class.schema_to_table(schema)
+
+      expect(rows).to include(
+        hash_including(
+          field: "a.b.c",
+          type: "string",
+          description: "deep value"
+        )
+      )
+    end
+
+    it "handles arrays without items safely" do
+      schema = {
+        "type" => "array",
+        "description" => "list of values"
+      }
+
+      rows = described_class.schema_to_table(schema)
+
+      expect(rows).to include(
+        hash_including(
+          type: "array",
+          description: "list of values"
+        )
+      )
+    end
+
+    it "handles scalar schemas directly" do
+      schema = {
+        "type" => "string",
+        "description" => "a field"
+      }
+
+      rows = described_class.schema_to_table(schema, "field")
+
+      expect(rows).to include(
+        hash_including(
+          field: "field",
+          type: "string",
+          description: "a field",
+          required: false
+        )
+      )
+    end
   end
 
   describe ".build_row" do
@@ -227,6 +345,30 @@ RSpec.describe ApiDocs::OpenapiSpecification do
           enum: ["a", "b"],
           nullable: true
         }
+      )
+    end
+
+    it "omits nil values" do
+      row = described_class.build_row(
+        { "type" => "string" },
+        "field",
+        required: []
+      )
+
+      expect(row).to include(field: "field", type: "string")
+      expect(row).not_to have_key(:format)
+      expect(row).not_to have_key(:enum)
+      expect(row).not_to have_key(:nullable)
+    end
+  end
+
+  describe "OpenAPI path consistency" do
+    it "keeps endpoints aligned with OpenAPI specification paths" do
+      paths = described_class.specification["paths"].keys
+
+      expect(paths).to include(
+        "/api/{api_version}/info",
+        "/api/{api_version}/providers"
       )
     end
   end

--- a/spec/lib/api_docs/openapi_specification_spec.rb
+++ b/spec/lib/api_docs/openapi_specification_spec.rb
@@ -41,67 +41,77 @@ RSpec.describe ApiDocs::OpenapiSpecification do
   end
 
   context "manually added descriptions" do
-    context "parameters-level descriptions" do
-      it "ensures all parameters across all endpoints have descriptions" do
-        spec = described_class.specification
-        spec["paths"].each do |path, path_item|
-          path_item.each do |method, operation|
-            next unless operation.is_a?(Hash)
-            next unless operation["parameters"]
+    let(:openapi_data) { YAML.load_file(Rails.root.join("spec/support/openapi/post_documentation.yml")) }
+    let(:spec) { described_class.specification }
+    def find_param(path, method, param_name)
+      spec.dig("paths", path, method, "parameters")&.find { |p| p["name"] == param_name }
+    end
 
-            operation["parameters"].each do |param|
-              expect(param["description"]).to be_present,
-                                              "Missing description for #{method.upcase} #{path} parameter #{param['name']}"
-            end
+    def find_property(prop_name)
+      spec.dig("paths", "/api/{api_version}/providers", "get", "responses", "200", "content", "application/json", "schema", "properties", "data", "items", "properties", prop_name)
+    end
+
+    context "parameters-level descriptions" do
+      it "matches the data.yml for all parameters" do
+        ["/api/{api_version}/info", "/api/{api_version}/providers"].each do |path|
+          openapi_data["parameters"].each do |name, description|
+            param = find_param(path, "get", name)
+            next unless param #
+
+            expect(param["description"].squish).to eq(description.squish)
           end
         end
-      end
-
-      shared_examples "parameters-level descriptions" do |hash_keys, descriptions|
-        it "has description for #{hash_keys.join(' -> ')}" do
-          expect(described_class.specification.dig(*hash_keys).pluck("description").map(&:squish)).to eq(descriptions)
-        end
-      end
-
-      context "manually added parameters-level descriptions" do
-        it_behaves_like "parameters-level descriptions", ["paths", "/api/{api_version}/info", "get", "parameters"], [
-          "A valid API token must be provided in the Authorization header to access this endpoint.",
-          "The API version to use in the request path. This should be set to the latest version for this endpoint."
-        ]
-
-        it_behaves_like "parameters-level descriptions", ["paths", "/api/{api_version}/providers", "get", "parameters"], [
-          "A valid API token must be provided in the Authorization header to access this endpoint.",
-          "Filters providers by the specified academic year. The value must be a 4-digit year, for example 2025. If not provided, the API will return providers active in the current academic year.",
-          "The API version to use in the request path. This should be set to the latest version for this endpoint.",
-          "Filters providers to only those updated after the specified timestamp. The value must be an ISO 8601 datetime, for example: 2025-09-14T11:34:56Z.",
-        ]
       end
     end
 
     context "operation-level descriptions" do
-      it "ensures all operations across all endpoints have descriptions" do
-        spec = described_class.specification
-        spec["paths"].each do |path, path_item|
-          path_item.each do |method, operation|
-            next unless operation.is_a?(Hash)
-            # Skip keys that aren't HTTP verbs
-            next unless %w[get post put patch delete options head].include?(method.downcase)
+      it "matches the data.yml for endpoint descriptions" do
+        openapi_data["endpoints"].each do |path_key, data|
+          # Find the path in the spec that includes our key
+          full_path = spec["paths"].keys.find { |k| k.include?(path_key) }
+          description = spec.dig("paths", full_path, "get", "description")
 
-            expect(operation["description"]).to be_present,
-                                                "Missing description for #{method.upcase} #{path} operation"
-          end
+          expect(description.squish).to eq(data["description"].squish)
         end
       end
+    end
 
-      shared_examples "operation-level description" do |hash_keys, descriptions|
-        it "has description for #{hash_keys.join(' -> ')}" do
-          expect(described_class.specification.dig(*hash_keys).squish).to eq(descriptions)
+    it "adds the data collection description" do
+      data_property = spec.dig(
+        "paths",
+        "/api/{api_version}/providers",
+        "get",
+        "responses",
+        "200",
+        "content",
+        "application/json",
+        "schema",
+        "properties",
+        "data"
+      )
+
+      expect(data_property["description"]).to eq(
+        openapi_data.dig(
+          "providers_properties",
+          "data",
+          "description"
+        )
+      )
+    end
+
+    context "provider property descriptions" do
+      it "matches the data.yml for all provider properties" do
+        openapi_data["provider_properties"].each do |name, data|
+          property = find_property(name)
+
+          expect(property).to be_present, "Expected property '#{name}' to exist in schema"
+
+          expect(property["description"].squish).to eq(data["description"].squish)
+
+          expect(property["example"].to_s).to eq(data["example"].to_s) if data["example"]
+
+          expect(property["enum"]).to eq(data["enum"]) if data["enum"]
         end
-      end
-      context "manually added operation-level descriptions" do
-        it_behaves_like "operation-level description", ["paths", "/api/{api_version}/info", "get", "description"], "This endpoint can be used to retrieve general information about the API."
-        it_behaves_like "operation-level description", ["paths", "/api/{api_version}/providers", "get", "description"],
-                        "This endpoint can be used to retrieve providers for a given academic year. This is intended to make it possible to check for new or updated providers regularly."
       end
     end
   end

--- a/spec/lib/api_docs/openapi_specification_spec.rb
+++ b/spec/lib/api_docs/openapi_specification_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ApiDocs::OpenapiSpecification do
         ["/api/{api_version}/info", "/api/{api_version}/providers"].each do |path|
           openapi_data["parameters"].each do |name, description|
             param = find_param(path, "get", name)
-            next unless param #
+            next unless param
 
             expect(param["description"].squish).to eq(description.squish)
           end
@@ -113,6 +113,121 @@ RSpec.describe ApiDocs::OpenapiSpecification do
           expect(property["enum"]).to eq(data["enum"]) if data["enum"]
         end
       end
+    end
+  end
+
+  describe ".endpoint_table" do
+    it "returns a flattened schema table for providers" do
+      rows = described_class.endpoint_table("/providers", :get)
+
+      expect(rows).to be_an(Array)
+      expect(rows).not_to be_empty
+
+      expect(rows.first).to include(
+        :field,
+        :type
+      )
+    end
+  end
+
+  describe ".schema_to_table" do
+    let(:schema) do
+      {
+        "type" => "object",
+        "required" => ["id"],
+        "properties" => {
+          "id" => {
+            "type" => "string",
+            "description" => "Provider identifier",
+            "example" => "123"
+          },
+          "providers" => {
+            "type" => "array",
+            "description" => "List of providers",
+            "items" => {
+              "type" => "object",
+              "required" => ["name"],
+              "properties" => {
+                "name" => {
+                  "type" => "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it "flattens object properties" do
+      rows = described_class.schema_to_table(schema)
+
+      expect(rows).to include(
+        hash_including(
+          field: "id",
+          type: "string",
+          required: true,
+          description: "Provider identifier",
+          example: "123"
+        )
+      )
+    end
+
+    it "includes array rows" do
+      rows = described_class.schema_to_table(schema)
+
+      expect(rows).to include(
+        hash_including(
+          field: "providers",
+          type: "array",
+          description: "List of providers"
+        )
+      )
+    end
+
+    it "flattens nested array items" do
+      rows = described_class.schema_to_table(schema)
+
+      expect(rows).to include(
+        hash_including(
+          field: "providers[].name",
+          type: "string",
+          required: true
+        )
+      )
+    end
+
+    it "returns an empty array for invalid schemas" do
+      expect(described_class.schema_to_table(nil)).to eq([])
+      expect(described_class.schema_to_table("foo")).to eq([])
+      expect(described_class.schema_to_table([])).to eq([])
+    end
+  end
+
+  describe ".build_row" do
+    it "includes format, enum and nullable when present" do
+      row = described_class.build_row(
+        {
+          "type" => "string",
+          "format" => "date-time",
+          "enum" => ["a", "b"],
+          "nullable" => true,
+          "description" => "A field"
+        },
+        "updated_at",
+        required: ["updated_at"]
+      )
+
+      expect(row).to eq(
+        {
+          field: "updated_at",
+          type: "string",
+          format: "date-time",
+          required: true,
+          description: "A field",
+          enum: ["a", "b"],
+          nullable: true
+        }
+      )
     end
   end
 end

--- a/spec/presenters/api_docs/api_doc_presenter_spec.rb
+++ b/spec/presenters/api_docs/api_doc_presenter_spec.rb
@@ -1,48 +1,89 @@
 require "rails_helper"
 
 RSpec.describe ApiDocs::ApiDocPresenter do
-  subject(:presenter) { described_class.new(spec:, method:) }
+  subject(:presenter) { described_class.new(doc:, method:) }
 
+  let(:doc) { "providers" }
   let(:method) { :get }
 
-  let(:spec) do
-    {
-      heading: "Providers",
-      path: "/providers",
-      specifications: {
-        get: {
-          summary: "Returns a list of providers",
-          parameters: [
-            {
-              name: :updated_since,
-              in: :query,
-              required: false,
-              schema: { type: :string },
-              description: "Filter by update timestamp",
-              example: "2025-09-14T11:34:56Z"
-            }
-          ],
-          responses: {
-            "200" => {
-              description: "Successful response",
-              content: {
-                "application/json" => {
-                  example: { data: [{ id: 1 }] }
+  before do
+    allow(ApiDocs::OpenapiSpecification).to receive(:endpoints).and_return(
+      {
+        "/providers" => {
+          heading: "Providers",
+          path: "/providers",
+          specifications: {
+            get: {
+              summary: "Returns a list of providers",
+              parameters: [
+                {
+                  name: :updated_since,
+                  in: :query,
+                  required: false,
+                  schema: { type: :string },
+                  description: "Filter by update timestamp",
+                  example: "2025-09-14T11:34:56Z"
                 }
-              }
-            },
-            "401" => {
-              description: "Unauthorised",
-              content: {
-                "application/json" => {
-                  example: { error: "Invalid token" }
+              ],
+              responses: {
+                "200" => {
+                  description: "Successful response",
+                  content: {
+                    "application/json" => {
+                      example: { data: [{ id: 1 }] }
+                    }
+                  }
+                },
+                "401" => {
+                  description: "Unauthorised",
+                  content: {
+                    "application/json" => {
+                      example: { error: "Invalid token" }
+                    }
+                  }
                 }
               }
             }
           }
         }
       }
-    }
+    )
+
+    allow(ApiDocs::OpenapiSpecification).to receive(:endpoint_table)
+      .with("/providers", :get)
+      .and_return(
+        [
+          {
+            field: "data[].id",
+            type: "string",
+            required: true,
+            description: "Provider ID",
+            example: "123"
+          }
+        ]
+      )
+  end
+
+  describe "#spec" do
+    it "returns the endpoint specification" do
+      expect(presenter.spec[:heading]).to eq("Providers")
+    end
+  end
+
+  describe "#schema" do
+    it "returns the endpoint schema table" do
+      expect(presenter.schema).to eq(
+        [
+          {
+            field: "data[].id",
+            type: "string",
+            required: true,
+            description: "Provider ID",
+            example: "123"
+          }
+        ]
+      )
+    end
   end
 
   describe "#heading" do

--- a/spec/requests/api/v0/get_providers_spec.rb
+++ b/spec/requests/api/v0/get_providers_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe "`GET /providers` endpoint", type: :request do
         create(:provider, trait)
       end
 
+      latest_providers.sort_by! do |provider|
+        [
+          provider.updated_at,
+          provider.operating_name,
+          provider.id,
+        ]
+      end
+
       get("/api/#{version}/providers", headers:, params:)
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Error Pages", type: :request do
   describe "GET /422" do
     it "renders the 422 error page" do
       get "/422"
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("Sorry, there’s a problem with the service")
     end
   end

--- a/spec/support/openapi.rb
+++ b/spec/support/openapi.rb
@@ -33,7 +33,7 @@ if generate_openapi
                                            end
     end
 
-    config.after(:suite) do
+    at_exit do
       puts "\nGenerated API docs:"
       Dir["public/openapi/*.yaml"].each { |file| puts " - #{file}" }
     end

--- a/spec/support/openapi/post_documentation.yml
+++ b/spec/support/openapi/post_documentation.yml
@@ -1,0 +1,90 @@
+provider_properties: &provider_properties
+  id:
+    description: The unique UUID identifier for the training provider.
+    example: 7bcf4928-a0c7-4fa7-aa46-d4297eec31e0
+
+  accreditation_status:
+    description: The current accreditation status of the provider.
+    enum: [accredited, unaccredited]
+    example: accredited
+
+  code:
+    description: The unique 3-character identifier code for the provider.
+    example: 1BJ
+
+  operating_name:
+    description: The primary business or operating name of the training provider.
+    example: Bobby Jacob University
+
+  provider_type:
+    description: The classification of the provider.
+    enum: [hei, scitt, school, other]
+    example: hei
+
+  ukprn:
+    description: The 8-digit UK Provider Reference Number.
+    example: "77336264"
+
+  updated_at:
+    description: The ISO 8601 timestamp of when the provider record was last modified.
+    format: date-time
+    example: "2025-09-15T11:34:56Z"
+
+  urn:
+    description: The 6-digit Unique Reference Number for schools.
+    example: "543380"
+
+paths:
+  "/api/{api_version}/info":
+    description: This endpoint can be used to retrieve general information about the API.
+    responses:
+      "200":
+        application/json:
+          schema:
+            properties:
+              status:
+                description: The status of the request.
+                example: ok
+              version:
+                properties:
+                  requested:
+                    description: The requested API version.
+                    example: v0
+                  latest:
+                    description: The latest available API version.
+                    example: v0
+
+  "/api/{api_version}/providers":
+    description: |
+      This endpoint can be used to retrieve providers for a given academic year.
+      This is intended to make it possible to check for new or updated providers regularly.
+    responses:
+      "200":
+        application/json:
+          schema:
+            properties:
+              data:
+                description: An array of training provider objects matching the specified filters.
+                items:
+                  properties: *provider_properties
+
+parameters:
+  Authorization:
+    description: A valid API token must be provided in the Authorization header to access this endpoint.
+
+  api_version:
+    description: |
+      The API version to use in the request path.
+      This should be set to the latest version for this endpoint.
+
+  academic_year:
+    description: |
+      Filters providers by the specified academic year.
+      The value must be a 4-digit year, for example 2025.
+
+      If not provided, the API will return providers active in the current academic year.
+
+  changed_since:
+    description: |
+      Filters providers to only those updated after the specified timestamp.
+      The value must be an ISO 8601 datetime, for example: 2025-09-14T11:34:56Z.

--- a/spec/support/openapi/post_process_hook.rb
+++ b/spec/support/openapi/post_process_hook.rb
@@ -1,7 +1,7 @@
 generate_openapi = ENV.fetch("OPENAPI", nil) == "1"
 
 module OpenApiPostProcess
-  extend self
+module_function
 
   def deep_merge!(target, source)
     return target unless target && source
@@ -64,7 +64,7 @@ if generate_openapi
     spec.fetch("paths", {}).each do |route, path_data|
       path_patch = path_overrides[route]
 
-      path_data.each do |_verb, op|
+      path_data.each_value do |op|
         next unless op.is_a?(Hash)
 
         OpenApiPostProcess.apply_parameter_overrides!(op, param_overrides)

--- a/spec/support/openapi/post_process_hook.rb
+++ b/spec/support/openapi/post_process_hook.rb
@@ -1,0 +1,80 @@
+generate_openapi = ENV.fetch("OPENAPI", nil) == "1"
+
+module OpenApiPostProcess
+  extend self
+
+  def deep_merge!(target, source)
+    return target unless target && source
+
+    source.each do |key, value|
+      if target[key].is_a?(Hash) && value.is_a?(Hash)
+        deep_merge!(target[key], value)
+      else
+        target[key] = value
+      end
+    end
+
+    target
+  end
+
+  def apply_parameter_overrides!(operation, overrides)
+    operation["parameters"]&.each do |parameter|
+      override = overrides[parameter["name"]]
+      next unless override
+
+      parameter["description"] =
+        override.is_a?(Hash) ? override["description"] : override
+    end
+  end
+
+  def apply_schema_patch!(operation, path_patch)
+    schema = operation.dig(
+      "responses",
+      "200",
+      "content",
+      "application/json",
+      "schema"
+    )
+
+    return unless schema
+
+    schema_patch = path_patch.dig(
+      "responses",
+      "200",
+      "application/json",
+      "schema"
+    )
+
+    deep_merge!(schema, schema_patch) if schema_patch
+  end
+end
+
+if generate_openapi
+  OPENAPI_DATA = YAML.load_file(
+    Rails.root.join("spec/support/openapi/post_documentation.yml"),
+    aliases: true
+  )
+
+  RSpec::OpenAPI.post_process_hook = lambda do |_path, _records, spec|
+    spec.deep_stringify_keys!
+
+    path_overrides = OPENAPI_DATA["paths"] || {}
+    param_overrides = OPENAPI_DATA["parameters"] || {}
+
+    spec.fetch("paths", {}).each do |route, path_data|
+      path_patch = path_overrides[route]
+
+      path_data.each do |_verb, op|
+        next unless op.is_a?(Hash)
+
+        OpenApiPostProcess.apply_parameter_overrides!(op, param_overrides)
+
+        next unless path_patch
+
+        op["description"] = path_patch["description"] if path_patch["description"]
+
+        OpenApiPostProcess.apply_schema_patch!(op, path_patch)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Due to rspec-openap limitation.

The intended serializer did not materialised, as it was not feaisble to use to create schema for end points.

Opted for implementing an overlay via post process hook in order to add descriptions to fields, as that was needed to describe what the fields are.


### Changes proposed in this pull request

Before the `v0.yml` is written, use `post_documentation.yml` to overlay the descriptions, so when written it now has the descriptions.

Said descriptions can now be viewed under the schema of that end point.

### Guidance to review
The limitation was the unreasonable upkeep of using the serializer that did not solve the problem but also added more fragmentation and nonsense.

The serializer was originally intended to help document the fields except it forces the need to perform manual updates that will be hard to validate and can be easily lost without realisation.

#### To test
##### From scratch

Run,
```
rm public/openapi/*
OPENAPI=1 bundle exec rspec spec/requests/api/v0/
```

The regenerated `v0.yml` should be exacting.

##### Amend `post_documentation.yml`

Make a change to one of the existing description.

Run,
```
OPENAPI=1 bundle exec rspec spec/requests/api/v0/
```

The regenerated `v0.yml` should be reflect the changes.

##### Forgetfulness

Make a change to one of the existing description in `post_documentation.yml`

Run,
```
bin/verify_openapi
```

It tells you there is a drift.

#### Screensnots

https://register-training-providers-pr-492.test.teacherservices.cloud/api-docs/get/info

<img width="990" height="284" alt="image" src="https://github.com/user-attachments/assets/02920196-e31f-4a44-81eb-33875f71b822" />

https://register-training-providers-pr-492.test.teacherservices.cloud/api-docs/get/providers

<img width="990" height="1251" alt="image" src="https://github.com/user-attachments/assets/3b235310-25e5-4cdb-aada-175b8884d774" />


