### PR TITLE
[0479] Added onboarded_at & first_active_at to the summary card rows for provider

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -2,7 +2,8 @@ module ProviderHelper
   # Base rows for displaying provider details in summary cards/lists.
   # Used by: provider index cards, provider show page, activity log.
   def provider_summary_card_rows(provider, hide_provider_code: false, hide_ukprn: false, hide_urn: false,
-                                 use_details_for_academic_years_row: false)
+                                 use_details_for_academic_years_row: false, hide_onboarded_at: false,
+                                 hide_first_active_at: false)
     summary_card_rows = [
       { key: { text: "Provider type" }, value: { text: provider.provider_type_label } },
       { key: { text: "Accreditation status" }, value: { text: provider.accreditation_status_label } },
@@ -16,7 +17,14 @@ module ProviderHelper
                             value: optional_value(provider.urn) }] unless hide_urn
     summary_card_rows += [{ key: { text: "Provider code" },
                             value: { text: provider.code } }] unless hide_provider_code
-
+    summary_card_rows += [{ key: { text: "Onboard at" },
+                            value: {
+                              text: provider.onboarded_at.to_fs(:govuk)
+                            } }] unless hide_onboarded_at
+    summary_card_rows += [{ key: { text: "First active at" },
+                            value: {
+                              text: provider.first_active_at.to_fs(:govuk)
+                            } }] unless hide_first_active_at
     summary_card_rows += [academic_years_row(provider.academic_years.order(duration: :desc),
                                              use_details_for_academic_years_row)]
 
@@ -62,7 +70,9 @@ module ProviderHelper
           hide_provider_code: true,
           hide_ukprn: true,
           hide_urn: true,
-          use_details_for_academic_years_row: true
+          use_details_for_academic_years_row: true,
+          hide_onboarded_at: true,
+          hide_first_active_at: true
         )
       }
     end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -208,6 +208,8 @@ RSpec.describe ProviderHelper, type: :helper do
           value: { text: provider.code },
           actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
         },
+        { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
+        { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
         {
           key: { text: "Academic years" },
           value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
@@ -254,6 +256,8 @@ RSpec.describe ProviderHelper, type: :helper do
             value: { text: provider.code },
             actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
           },
+          { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
+          { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
           {
             key: { text: "Academic years" },
             value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },


### PR DESCRIPTION
### Context
onboarded_at & first_active_at
### Changes proposed in this pull request
Display onboarded_at & first_active_at to the summary card rows for provider
### Guidance to review
<img width="1920" height="2092" alt="image" src="https://github.com/user-attachments/assets/cfbd679c-fefc-41fb-833f-0bd270aa97a7" />
