### PR TITLE
[480] - Display the inactive periods on the summary list on the provider details page

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -20,6 +20,9 @@ module ProviderHelper
     summary_card_rows += [academic_years_row(provider.academic_years.order(duration: :desc),
                                              use_details_for_academic_years_row)]
 
+    summary_card_rows += [{ key: { text: "Inactive periods" },
+                            value: { text: inactive_periods_html(provider.inactive_periods) } }]
+
     summary_card_rows
   end
 
@@ -127,5 +130,30 @@ module ProviderHelper
     end
 
     rows
+  end
+
+  def inactive_periods_html(inactive_periods)
+    return content_tag(:p, "No inactive periods") if inactive_periods.empty?
+
+    content_tag(:ul, class: "govuk-list govuk-list") do
+      inactive_periods.map { |period|
+        content_tag(:li, govuk_summary_list(rows: display_inactive_period(period)))
+      }.join.html_safe
+    end
+  end
+
+  def display_inactive_period(period)
+    [
+      { key: { text: "Starts on" },
+        value: { text: display_date(period["start_date"]) } },
+      { key: { text: "Ends on" },
+        value: { text: display_date(period["end_date"]) } },
+    ]
+  end
+
+  def display_date(date)
+    return "Not entered" if date.blank?
+
+    date.to_date.to_fs(:govuk)
   end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -28,8 +28,10 @@ module ProviderHelper
     summary_card_rows += [academic_years_row(provider.academic_years.order(duration: :desc),
                                              use_details_for_academic_years_row)]
 
-    summary_card_rows += [{ key: { text: "Inactive periods" },
-                            value: { text: inactive_periods_html(provider.inactive_periods) } }] unless hide_inactive_periods
+    unless hide_inactive_periods
+      summary_card_rows += [{ key: { text: "Inactive periods" },
+                              value: { text: inactive_periods_html(provider.inactive_periods) } }]
+    end
 
     summary_card_rows
   end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -74,7 +74,7 @@ module ProviderHelper
           hide_ukprn: true,
           hide_urn: true,
           use_details_for_academic_years_row: true,
-          hide_inactive_periods: true
+          hide_inactive_periods: true,
           hide_onboarded_at: true,
           hide_first_active_at: true
         )

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -2,7 +2,7 @@ module ProviderHelper
   # Base rows for displaying provider details in summary cards/lists.
   # Used by: provider index cards, provider show page, activity log.
   def provider_summary_card_rows(provider, hide_provider_code: false, hide_ukprn: false, hide_urn: false,
-                                 use_details_for_academic_years_row: false)
+                                 use_details_for_academic_years_row: false, hide_inactive_periods: false)
     summary_card_rows = [
       { key: { text: "Provider type" }, value: { text: provider.provider_type_label } },
       { key: { text: "Accreditation status" }, value: { text: provider.accreditation_status_label } },
@@ -21,7 +21,7 @@ module ProviderHelper
                                              use_details_for_academic_years_row)]
 
     summary_card_rows += [{ key: { text: "Inactive periods" },
-                            value: { text: inactive_periods_html(provider.inactive_periods) } }]
+                            value: { text: inactive_periods_html(provider.inactive_periods) } }] unless hide_inactive_periods
 
     summary_card_rows
   end
@@ -65,7 +65,8 @@ module ProviderHelper
           hide_provider_code: true,
           hide_ukprn: true,
           hide_urn: true,
-          use_details_for_academic_years_row: true
+          use_details_for_academic_years_row: true,
+          hide_inactive_periods: true
         )
       }
     end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -276,7 +276,8 @@ RSpec.describe ProviderHelper, type: :helper do
     end
 
     context "when the provider has inactive periods" do
-      let(:provider) { create(:provider, :scitt, :with_inactive_period) }
+      let(:onboard_date) { 3.years.ago }
+      let(:provider) { create(:provider, :scitt, :with_inactive_period, onboarded_at: onboard_date, first_active_at: onboard_date) }
 
       it "returns the expected rows without 'Not entered'" do
         expect(helper.provider_details_rows(provider)).to eq([
@@ -312,6 +313,14 @@ RSpec.describe ProviderHelper, type: :helper do
             key: { text: "Provider code" },
             value: { text: provider.code },
             actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
+          },
+          {
+            key: { text: "Onboard at" },
+            value: { text: onboard_date.to_date.to_fs(:govuk) }
+          },
+          {
+            key: { text: "First active at" },
+            value: { text: onboard_date.to_date.to_fs(:govuk) }
           },
           {
             key: { text: "Academic years" },

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ProviderHelper, type: :helper do
         { key: { text: "Operating name" }, value: { text: provider.operating_name } },
         { key: { text: "Legal name" }, value: { text: "Not entered", classes: "govuk-hint" } },
         { key: { text: "Academic years" }, value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' } },
+        { key: { text: "Inactive periods" }, value: { text: "<p>No inactive periods</p>" } },
       ])
     end
 
@@ -213,6 +214,10 @@ RSpec.describe ProviderHelper, type: :helper do
           value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
           actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
         },
+        {
+          key: { text: "Inactive periods" },
+          value: { text: "<p>No inactive periods</p>" }
+        },
       ])
     end
 
@@ -258,6 +263,61 @@ RSpec.describe ProviderHelper, type: :helper do
             key: { text: "Academic years" },
             value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
             actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
+          },
+          {
+            key: { text: "Inactive periods" },
+            value: { text: "<p>No inactive periods</p>" }
+          },
+        ])
+      end
+    end
+
+    context "when the provider has inactive periods" do
+      let(:provider) { create(:provider, :scitt, :with_inactive_period) }
+
+      it "returns the expected rows without 'Not entered'" do
+        expect(helper.provider_details_rows(provider)).to eq([
+          {
+            key: { text: "Provider type" },
+            value: { text: provider.provider_type_label },
+          },
+          {
+            key: { text: "Accreditation status" },
+            value: { text: provider.accreditation_status_label },
+          },
+          {
+            key: { text: "Operating name" },
+            value: { text: provider.operating_name },
+            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "operating name" }],
+          },
+          {
+            key: { text: "Legal name" },
+            value: { text: provider.legal_name },
+            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "legal name" }],
+          },
+          {
+            key: { text: "UK provider reference number (UKPRN)" },
+            value: { text: provider.ukprn },
+            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "UK provider reference number (UKPRN)" }],
+          },
+          {
+            key: { text: "Unique reference number (URN)" },
+            value: { text: provider.urn },
+            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "unique reference number (URN)" }],
+          },
+          {
+            key: { text: "Provider code" },
+            value: { text: provider.code },
+            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
+          },
+          {
+            key: { text: "Academic years" },
+            value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
+            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
+          },
+          {
+            key: { text: "Inactive periods" },
+            value: { text: "<ul class=\"govuk-list govuk-list\"><li><dl class=\"govuk-summary-list\"><div class=\"govuk-summary-list__row\"><dt class=\"govuk-summary-list__key\">Starts on</dt><dd class=\"govuk-summary-list__value\">1 August 2024</dd></div><div class=\"govuk-summary-list__row\"><dt class=\"govuk-summary-list__key\">Ends on</dt><dd class=\"govuk-summary-list__value\">1 August 2025</dd></div></dl></li></ul>" }
           },
         ])
       end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe ProviderHelper, type: :helper do
         { key: { text: "Operating name" }, value: { text: provider.operating_name } },
         { key: { text: "Legal name" }, value: { text: "Not entered", classes: "govuk-hint" } },
         { key: { text: "Academic years" }, value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' } },
-        { key: { text: "Inactive periods" }, value: { text: "<p>No inactive periods</p>" } },
       ])
     end
 

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -144,5 +144,18 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :with_inactive_period do
+      after(:create) do |provider|
+        if provider.inactive_periods.empty?
+          previous_academic_year = create(:academic_year, :previous)
+
+          provider.inactive_periods << { start_date: previous_academic_year.duration.begin,
+                                         end_date: previous_academic_year.duration.end,
+                                         reason_for_inactive: "None given" }
+          provider.save!
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/ONdJJpBt/480-display-the-inactive-periods-on-the-summary-list-on-the-provider-details-page

### Changes proposed in this pull request

Display inactive periods for providers

<img width="3348" height="3314" alt="Screenshot 2026-06-17 at 10-14-12 2Schools Consortium - Provider - Register of training providers - GOV UK" src="https://github.com/user-attachments/assets/10b2346c-143c-4f72-9022-0286ea0653ab" />



### Guidance to review
