### PR TITLE
[0482] Add a provider journey when did the provider onboard

### DIFF
--- a/app/controllers/providers/check_controller.rb
+++ b/app/controllers/providers/check_controller.rb
@@ -1,6 +1,6 @@
 class Providers::CheckController < CheckController
   helper_method :change_provider_type_path, :accreditation_form, :change_provider_details_path, :address_form,
-                :change_address_path
+                :change_address_path, :change_provider_onboarding_path, :change_provider_first_become_active_path
 
 private
 
@@ -10,6 +10,18 @@ private
                else
                  provider_session.load_provider || Provider.new
                end
+  end
+
+  def change_provider_onboarding_path
+    if model_id.nil?
+      new_provider_onboarding_path(goto: "confirm")
+    end
+  end
+
+  def change_provider_first_become_active_path
+    if model_id.nil?
+      new_provider_first_become_active_path(goto: "confirm")
+    end
   end
 
   def change_provider_type_path

--- a/app/controllers/providers/details_controller.rb
+++ b/app/controllers/providers/details_controller.rb
@@ -4,8 +4,22 @@ class Providers::DetailsController < CheckController
   def new
     # Validate previous steps from session
     onboarding_data = provider_session.load_onboarding
-    if onboarding_data.nil? || Providers::IsTheProviderAccredited.new(onboarding_data).invalid?
+    onboarding_form = Providers::OnboardingForm.new(onboarding_data)
+    if onboarding_data.nil? || onboarding_form.invalid?
       redirect_to new_provider_onboarding_path
+      return
+    end
+
+    first_become_active_data = provider_session.load_first_become_active
+    first_become_active_form = Providers::FirstBecomeActiveForm.new(first_become_active_data)
+    if first_become_active_data.nil? || first_become_active_form.invalid?
+      redirect_to new_provider_first_become_active_path
+      return
+    end
+
+    is_provider_accredited_data = provider_session.load_is_provider_accredited
+    if is_provider_accredited_data.nil? || Providers::IsTheProviderAccredited.new(is_provider_accredited_data).invalid?
+      redirect_to new_provider_is_provider_accredited_path
       return
     end
 
@@ -20,8 +34,12 @@ class Providers::DetailsController < CheckController
     # Only set provider_type attributes if this is a fresh provider (not loaded from session)
     if @provider.nil?
       @provider = Provider.new
-      @provider.assign_attributes(provider_type_data)
+      provider_attributes = provider_type_data.merge({ onboarded_at: onboarding_form.onboarded_at,
+                                                       first_active_at: first_become_active_form.first_active_at })
+
     end
+
+    @provider.assign_attributes(provider_attributes)
 
     render :new
   end
@@ -36,7 +54,7 @@ class Providers::DetailsController < CheckController
       provider_session.store_provider(
         @provider.attributes.slice(
           "provider_type", "accreditation_status", "operating_name",
-          "legal_name", "ukprn", "urn", "code"
+          "legal_name", "ukprn", "urn", "code", "onboarded_at", "first_active_at"
         )
       )
 
@@ -53,7 +71,15 @@ private
   end
 
   def create_new_provider_params
-    params.expect(provider: [:provider_type, :accreditation_status, :operating_name, :ukprn, :code, :urn, :legal_name])
+    params.expect(provider: [:provider_type,
+                             :accreditation_status,
+                             :operating_name,
+                             :ukprn,
+                             :code,
+                             :urn,
+                             :legal_name,
+                             :onboarded_at,
+                             :first_active_at])
   end
 
   def journey_coordinator(current_step, provider)

--- a/app/controllers/providers/details_controller.rb
+++ b/app/controllers/providers/details_controller.rb
@@ -36,10 +36,9 @@ class Providers::DetailsController < CheckController
       @provider = Provider.new
       provider_attributes = provider_type_data.merge({ onboarded_at: onboarding_form.onboarded_at,
                                                        first_active_at: first_become_active_form.first_active_at })
+      @provider.assign_attributes(provider_attributes)
 
     end
-
-    @provider.assign_attributes(provider_attributes)
 
     render :new
   end

--- a/app/controllers/providers/first_become_active_controller.rb
+++ b/app/controllers/providers/first_become_active_controller.rb
@@ -9,14 +9,14 @@ class Providers::FirstBecomeActiveController < CheckController
       return
     end
 
-    onboarding_form = Providers::Onboarding.new(onboarding_data)
+    onboarding_form = Providers::OnboardingForm.new(onboarding_data)
     if onboarding_form.invalid?
       redirect_to new_provider_onboarding_path
       return
     end
 
     first_become_active_data = provider_session.load_first_become_active
-    @form = Providers::FirstBecomeActive.new(first_become_active_data || {})
+    @form = Providers::FirstBecomeActiveForm.new(first_become_active_data || {})
 
     @form.assign_attributes({ onboarded_at: onboarding_form.onboarded_at })
 
@@ -24,7 +24,7 @@ class Providers::FirstBecomeActiveController < CheckController
   end
 
   def create
-    @form = Providers::FirstBecomeActive.new(first_become_active_params)
+    @form = Providers::FirstBecomeActiveForm.new(first_become_active_params)
 
     if @form.valid?
       provider_session.store_first_become_active(@form.attributes)
@@ -58,7 +58,7 @@ private
   end
 
   def first_become_active_params
-    params.expect(provider: [*Providers::FirstBecomeActive::PARAM_CONVERSION.keys])
-      .transform_keys { |k| Providers::FirstBecomeActive::PARAM_CONVERSION.fetch(k, k) }
+    params.expect(provider: [*Providers::FirstBecomeActiveForm::PARAM_CONVERSION.keys])
+      .transform_keys { |k| Providers::FirstBecomeActiveForm::PARAM_CONVERSION.fetch(k, k) }
   end
 end

--- a/app/controllers/providers/first_become_active_controller.rb
+++ b/app/controllers/providers/first_become_active_controller.rb
@@ -29,6 +29,20 @@ class Providers::FirstBecomeActiveController < CheckController
     if @form.valid?
       provider_session.store_first_become_active(@form.attributes)
 
+      if from_check?
+        provider = provider_session.load_provider
+        provider_attributes = { first_active_at: @form.first_active_at }
+
+        provider.assign_attributes(provider_attributes)
+
+        provider_session.store_provider(
+          provider.attributes.slice(
+            "provider_type", "accreditation_status", "operating_name",
+            "legal_name", "ukprn", "urn", "code", "onboarded_at", "first_active_at"
+          )
+        )
+      end
+
       redirect_to journey_coordinator(:first_become_active, nil).next_path
     else
       render :new
@@ -45,8 +59,13 @@ private
     ProviderCreation::JourneyCoordinator.new(
       current_step: current_step,
       session_manager: provider_session,
-      provider: provider
+      provider: provider,
+      from_check: from_check?
     )
+  end
+
+  def from_check?
+    params[:goto] == "confirm"
   end
 
   def provider_session

--- a/app/controllers/providers/first_become_active_controller.rb
+++ b/app/controllers/providers/first_become_active_controller.rb
@@ -1,0 +1,64 @@
+class Providers::FirstBecomeActiveController < CheckController
+  helper_method :back_path
+
+  def new
+    onboarding_data = provider_session.load_onboarding
+
+    if onboarding_data.nil?
+      redirect_to new_provider_onboarding_path
+      return
+    end
+
+    onboarding_form = Providers::Onboarding.new(onboarding_data)
+    if onboarding_form.invalid?
+      redirect_to new_provider_onboarding_path
+      return
+    end
+
+    first_become_active_data = provider_session.load_first_become_active
+    @form = Providers::FirstBecomeActive.new(first_become_active_data || {})
+
+    @form.assign_attributes({ onboarded_at: onboarding_form.onboarded_at })
+
+    render :new
+  end
+
+  def create
+    @form = Providers::FirstBecomeActive.new(first_become_active_params)
+
+    if @form.valid?
+      provider_session.store_first_become_active(@form.attributes)
+
+      redirect_to journey_coordinator(:first_become_active, nil).next_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def back_path
+    journey_coordinator(:first_become_active, nil).back_path
+  end
+
+  def journey_coordinator(current_step, provider)
+    ProviderCreation::JourneyCoordinator.new(
+      current_step: current_step,
+      session_manager: provider_session,
+      provider: provider
+    )
+  end
+
+  def provider_session
+    @provider_session ||= ProviderCreation::SessionManager.new(session)
+  end
+
+  def address_session
+    @address_session ||= AddressJourney::SessionManager.new(session, context: :setup)
+  end
+
+  def first_become_active_params
+    params.expect(provider: [*Providers::FirstBecomeActive::PARAM_CONVERSION.keys])
+      .transform_keys { |k| Providers::FirstBecomeActive::PARAM_CONVERSION.fetch(k, k) }
+  end
+end

--- a/app/controllers/providers/is_the_provider_accredited_controller.rb
+++ b/app/controllers/providers/is_the_provider_accredited_controller.rb
@@ -1,0 +1,46 @@
+class Providers::IsTheProviderAccreditedController < CheckController
+  helper_method :back_path
+
+  def new
+    is_provider_accredited_data = provider_session.load_is_provider_accredited
+    @form = Providers::IsTheProviderAccredited.new(is_provider_accredited_data || {})
+  end
+
+  def create
+    @form = Providers::IsTheProviderAccredited.new(is_the_provider_accredited_params)
+
+    if @form.valid?
+      provider_session.store_is_provider_accredited(@form.attributes)
+
+      redirect_to journey_coordinator(:is_the_provider_accredited, nil).next_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def back_path
+    journey_coordinator(:is_the_provider_accredited, nil).back_path
+  end
+
+  def journey_coordinator(current_step, provider)
+    ProviderCreation::JourneyCoordinator.new(
+      current_step: current_step,
+      session_manager: provider_session,
+      provider: provider
+    )
+  end
+
+  def provider_session
+    @provider_session ||= ProviderCreation::SessionManager.new(session)
+  end
+
+  def address_session
+    @address_session ||= AddressJourney::SessionManager.new(session, context: :setup)
+  end
+
+  def is_the_provider_accredited_params
+    params.expect(provider: [:accreditation_status])
+  end
+end

--- a/app/controllers/providers/onboarding_controller.rb
+++ b/app/controllers/providers/onboarding_controller.rb
@@ -12,6 +12,21 @@ class Providers::OnboardingController < CheckController
     if @form.valid?
       provider_session.store_onboarding(@form.attributes)
 
+      if from_check?
+        provider = provider_session.load_provider
+
+        provider_attributes = { onboarded_at: @form.onboarded_at }
+
+        provider.assign_attributes(provider_attributes)
+
+        provider_session.store_provider(
+          provider.attributes.slice(
+            "provider_type", "accreditation_status", "operating_name",
+            "legal_name", "ukprn", "urn", "code", "onboarded_at", "first_active_at"
+          )
+        )
+      end
+
       redirect_to journey_coordinator(:onboarding, nil).next_path
     else
       render :new
@@ -19,6 +34,10 @@ class Providers::OnboardingController < CheckController
   end
 
 private
+
+  def from_check?
+    params[:goto] == "confirm"
+  end
 
   def back_path
     journey_coordinator(:onboarding, nil).back_path
@@ -28,7 +47,8 @@ private
     ProviderCreation::JourneyCoordinator.new(
       current_step: current_step,
       session_manager: provider_session,
-      provider: provider
+      provider: provider,
+      from_check: from_check?
     )
   end
 

--- a/app/controllers/providers/onboarding_controller.rb
+++ b/app/controllers/providers/onboarding_controller.rb
@@ -3,11 +3,11 @@ class Providers::OnboardingController < CheckController
 
   def new
     onboarding_data = provider_session.load_onboarding
-    @form = Providers::IsTheProviderAccredited.new(onboarding_data || {})
+    @form = Providers::OnboardingForm.new(onboarding_data || {})
   end
 
   def create
-    @form = Providers::IsTheProviderAccredited.new(accreditation_status_params)
+    @form = Providers::OnboardingForm.new(onboarding_params)
 
     if @form.valid?
       provider_session.store_onboarding(@form.attributes)
@@ -40,7 +40,8 @@ private
     @address_session ||= AddressJourney::SessionManager.new(session, context: :setup)
   end
 
-  def accreditation_status_params
-    params.expect(provider: [:accreditation_status])
+  def onboarding_params
+    params.expect(provider: [*Providers::OnboardingForm::PARAM_CONVERSION.keys])
+      .transform_keys { |k| Providers::OnboardingForm::PARAM_CONVERSION.fetch(k, k) }
   end
 end

--- a/app/controllers/providers/type_controller.rb
+++ b/app/controllers/providers/type_controller.rb
@@ -2,24 +2,23 @@ class Providers::TypeController < CheckController
   helper_method :back_path
 
   def new
-    onboarding_data = provider_session.load_onboarding
+    is_the_provider_accredited_data = provider_session.load_is_provider_accredited
 
-    if onboarding_data.nil?
-      redirect_to new_provider_onboarding_path
+    if is_the_provider_accredited_data.nil?
+      redirect_to new_provider_is_provider_accredited_path
       return
     end
 
-    # Validate the onboarding data
-    onboarding_form = Providers::IsTheProviderAccredited.new(onboarding_data)
-    if onboarding_form.invalid?
-      redirect_to new_provider_onboarding_path
+    is_the_provider_accredited_form = Providers::IsTheProviderAccredited.new(is_the_provider_accredited_data)
+    if is_the_provider_accredited_form.invalid?
+      redirect_to new_provider_is_provider_accredited_path
       return
     end
 
     provider_type_data = provider_session.load_provider_type
     @form = Providers::ProviderType.new(provider_type_data || {})
 
-    @form.assign_attributes(onboarding_data)
+    @form.assign_attributes(is_the_provider_accredited_data)
 
     render :new
   end

--- a/app/forms/providers/first_become_active_form.rb
+++ b/app/forms/providers/first_become_active_form.rb
@@ -1,0 +1,42 @@
+module Providers
+  class FirstBecomeActiveForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations::Callbacks
+
+    include GovukDateValidation
+    include GovukDateComponents
+
+    attribute :onboarded_at, :date
+
+    before_validation :convert_date_components
+
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "Provider")
+    end
+
+    def self.i18n_scope
+      :activerecord
+    end
+
+    def self.additional_params
+      [["onboarded_at", "onboarded_at"]]
+    end
+
+    has_date_components_with_choice :first_active_at_date
+
+    validates :first_active_at_date_choice, presence: true
+
+    validates :first_active_at_date, presence: true, if: -> { first_active_at_date_choice == "other" }
+
+    def predefined_dates
+      {
+        "same" => onboarded_at
+      }
+    end
+
+    def first_active_at
+      resolve_date_from_choice(:first_active_at_date)
+    end
+  end
+end

--- a/app/forms/providers/onboarding_form.rb
+++ b/app/forms/providers/onboarding_form.rb
@@ -1,0 +1,36 @@
+module Providers
+  class OnboardingForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations::Callbacks
+    include GovukDateValidation
+    include GovukDateComponents
+
+    has_date_components_with_choice :onboarded_at_date
+
+    validates :onboarded_at_date_choice, presence: true
+
+    validates :onboarded_at_date, presence: true, if: -> { onboarded_at_date_choice == "other" }
+
+    before_validation :convert_date_components
+
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "Provider")
+    end
+
+    def self.i18n_scope
+      :activerecord
+    end
+
+    def predefined_dates
+      {
+        "today" => Time.zone.today,
+        "yesterday" => Time.zone.yesterday,
+      }
+    end
+
+    def onboarded_at
+      resolve_date_from_choice(:onboarded_at_date)
+    end
+  end
+end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -93,7 +93,7 @@ module ProviderHelper
       value: { text: provider.onboarded_at.to_fs(:govuk) },
     }]
 
-    firat_active_at_row = [{
+    first_active_at_row = [{
       key: { text: "First active at" },
       value: { text: provider.first_active_at.to_fs(:govuk) },
     }]
@@ -109,7 +109,7 @@ module ProviderHelper
 
     [
       *onboarded_at_row,
-      *firat_active_at_row,
+      *first_active_at_row,
       *provider_type_row,
       { key: { text: "Operating name" },
         value: { text: provider.operating_name },

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -88,6 +88,15 @@ module ProviderHelper
   def provider_rows(provider, change_path, change_provider_type_path: nil, change_provider_details_path: nil)
     provider_details_change_path = change_provider_details_path || change_path
 
+    onboarded_at_row = [{
+      key: { text: "Onboarded at" },
+      value: { text: provider.onboarded_at.to_fs(:govuk) },
+    }]
+
+    firat_active_at_row = [{
+      key: { text: "First active at" },
+      value: { text: provider.first_active_at.to_fs(:govuk) },
+    }]
     provider_type_row = if change_provider_type_path
                           [{
                             key: { text: "Provider type" },
@@ -99,6 +108,8 @@ module ProviderHelper
                         end
 
     [
+      *onboarded_at_row,
+      *firat_active_at_row,
       *provider_type_row,
       { key: { text: "Operating name" },
         value: { text: provider.operating_name },

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -85,18 +85,34 @@ module ProviderHelper
   end
 
   # Rows for form check-your-answers pages with configurable change paths.
-  def provider_rows(provider, change_path, change_provider_type_path: nil, change_provider_details_path: nil)
+  def provider_rows(provider, change_path,
+                    change_provider_type_path: nil,
+                    change_provider_details_path: nil,
+                    change_provider_onboarding_path: nil,
+                    change_provider_first_become_active_path: nil)
     provider_details_change_path = change_provider_details_path || change_path
 
-    onboarded_at_row = [{
-      key: { text: "Onboard at" },
-      value: { text: provider.onboarded_at.to_fs(:govuk) },
-    }]
+    onboarded_at_row = if change_provider_onboarding_path
+                         [{
+                           key: { text: "Onboard at" },
+                           value: { text: provider.onboarded_at.to_fs(:govuk) },
+                           actions: [{ href: change_provider_onboarding_path, visually_hidden_text: "onboarded date" }]
+                         }]
+                       else
+                         []
+                       end
 
-    first_active_at_row = [{
-      key: { text: "First active at" },
-      value: { text: provider.first_active_at.to_fs(:govuk) },
-    }]
+    first_active_at_row = if change_provider_first_become_active_path
+                            [{
+                              key: { text: "First active at" },
+                              value: { text: provider.first_active_at.to_fs(:govuk) },
+                              actions: [{ href: change_provider_first_become_active_path,
+                                          visually_hidden_text: "first active date" }]
+                            }]
+                          else
+                            []
+                          end
+
     provider_type_row = if change_provider_type_path
                           [{
                             key: { text: "Provider type" },

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -89,7 +89,7 @@ module ProviderHelper
     provider_details_change_path = change_provider_details_path || change_path
 
     onboarded_at_row = [{
-      key: { text: "Onboarded at" },
+      key: { text: "Onboard at" },
       value: { text: provider.onboarded_at.to_fs(:govuk) },
     }]
 

--- a/app/models/concerns/govuk_date_components.rb
+++ b/app/models/concerns/govuk_date_components.rb
@@ -2,31 +2,65 @@ module GovukDateComponents
   extend ActiveSupport::Concern
 
   class_methods do
-    def has_date_components(*date_fields)
-      @date_fields = date_fields.freeze
+    def has_date_components_with_choice(*date_fields)
+      setup_component(*date_fields, choice: true)
+    end
 
+    def has_date_components(*date_fields)
+      setup_component(*date_fields, choice: false)
+    end
+
+  private
+
+    def setup_component(*date_fields, choice:)
       date_fields.each do |date_field|
         attribute :"#{date_field}_day", :integer
         attribute :"#{date_field}_month", :integer
         attribute :"#{date_field}_year", :integer
         attribute date_field, :date
+
+        attribute :"#{date_field}_choice", :string if choice
       end
 
       const_set(:DATE_FIELDS, date_fields.freeze)
-      const_set(:PARAM_CONVERSION, build_param_conversion(date_fields).freeze)
+      const_set(:PARAM_CONVERSION, build_param_conversion(date_fields, choice:).freeze)
+      const_set(:CHOICE, choice)
     end
 
-  private
-
-    def build_param_conversion(date_fields)
+    def build_param_conversion(date_fields, choice: false)
       date_fields.flat_map { |date_field|
-        [
+        mapping = [
           ["#{date_field}(3i)", "#{date_field}_day"],
           ["#{date_field}(2i)", "#{date_field}_month"],
           ["#{date_field}(1i)", "#{date_field}_year"]
         ]
+
+        if choice
+          mapping << ["#{date_field}_choice", "#{date_field}_choice"]
+          mapping.concat(additional_params)
+        end
+
+        mapping
       }.to_h
     end
+
+    def additional_params
+      []
+    end
+  end
+
+  def resolve_date_from_choice(field)
+    choice = public_send("#{field}_choice")
+
+    if choice.present? && choice != "other"
+      predefined_dates[choice]
+    else
+      build_date_from_components(field)
+    end
+  end
+
+  def predefined_dates
+    {}
   end
 
   def extract_date_components_from(source_object)
@@ -59,6 +93,12 @@ module GovukDateComponents
       ]
     }.to_h
 
+    if self.class::CHOICE
+      self.class::DATE_FIELDS.each do |date_field|
+        date_attributes["#{date_field}_choice"] = public_send("#{date_field}_choice")
+      end
+    end
+
     base_hash.merge(date_attributes)
   end
 
@@ -71,16 +111,14 @@ private
   end
 
   def build_date_from_components(date_field)
-    year = send("#{date_field}_year")
-    month = send("#{date_field}_month")
-    day = send("#{date_field}_day")
+    year  = public_send("#{date_field}_year")
+    month = public_send("#{date_field}_month")
+    day   = public_send("#{date_field}_day")
 
     return nil unless year.present? && month.present? && day.present?
 
-    begin
-      Date.new(year, month, day)
-    rescue ArgumentError
-      nil
-    end
+    Date.new(year.to_i, month.to_i, day.to_i)
+  rescue ArgumentError
+    nil
   end
 end

--- a/app/services/provider_creation/journey_coordinator.rb
+++ b/app/services/provider_creation/journey_coordinator.rb
@@ -21,6 +21,10 @@ module ProviderCreation
 
       case @current_step
       when :onboarding
+        new_provider_first_become_active_path
+      when :first_become_active
+        new_provider_is_the_provider_accredited_path
+      when :is_the_provider_accredited
         new_provider_type_path
       when :type
         new_provider_details_path
@@ -59,8 +63,12 @@ module ProviderCreation
       case @current_step
       when :onboarding
         providers_path
-      when :type
+      when :first_become_active
         new_provider_onboarding_path
+      when :is_the_provider_accredited
+        new_provider_first_become_active_path
+      when :type
+        new_provider_is_the_provider_accredited_path
       when :details
         new_provider_type_path
       when :accreditation

--- a/app/services/provider_creation/journey_coordinator.rb
+++ b/app/services/provider_creation/journey_coordinator.rb
@@ -15,7 +15,7 @@ module ProviderCreation
     def next_path
       # If we're in a change flow (from check page with goto=confirm),
       # redirect back to check page after successful submission
-      if @from_check && [:type, :details, :accreditation].include?(@current_step)
+      if @from_check && [:onboarding, :first_become_active, :type, :details, :accreditation].include?(@current_step)
         return new_provider_confirm_path
       end
 

--- a/app/services/provider_creation/session_manager.rb
+++ b/app/services/provider_creation/session_manager.rb
@@ -39,6 +39,14 @@ module ProviderCreation
       data[:first_become_active]
     end
 
+    def store_is_provider_accredited(attributes)
+      data[:is_provider_accredited] = attributes
+    end
+
+    def load_is_provider_accredited
+      data[:is_provider_accredited]
+    end
+
     def store_provider_type(attributes)
       data[:provider_type] = attributes
     end

--- a/app/services/provider_creation/session_manager.rb
+++ b/app/services/provider_creation/session_manager.rb
@@ -31,6 +31,14 @@ module ProviderCreation
       data[:onboarding]
     end
 
+    def store_first_become_active(attributes)
+      data[:first_become_active] = attributes
+    end
+
+    def load_first_become_active
+      data[:first_become_active]
+    end
+
     def store_provider_type(attributes)
       data[:provider_type] = attributes
     end

--- a/app/views/providers/check/new.html.erb
+++ b/app/views/providers/check/new.html.erb
@@ -4,8 +4,11 @@
 
 <% page_data(title: "Check your answers", subtitle: "Add provider", caption: "Add provider") %>
 
-<%= govuk_summary_list(rows: provider_rows(model, change_path, change_provider_type_path:, change_provider_details_path:)) %>
-
+<%= govuk_summary_list(rows: provider_rows(model, change_path,
+                                           change_provider_type_path:,
+                                           change_provider_details_path:,
+                                           change_provider_onboarding_path:,
+                                           change_provider_first_become_active_path:)) %>
 <% if accreditation_form&.valid? %>
   <h2 class="govuk-heading-m">Accreditation</h2>
   <%= govuk_summary_list(rows: accreditation_form_rows(accreditation_form)) %>

--- a/app/views/providers/details/_fields.html.erb
+++ b/app/views/providers/details/_fields.html.erb
@@ -1,5 +1,7 @@
-  <%= form.hidden_field :accreditation_status %>
-  <%= form.hidden_field :provider_type %>
+<%= form.hidden_field :accreditation_status %>
+<%= form.hidden_field :provider_type %>
+<%= form.hidden_field :onboarded_at %>
+<%= form.hidden_field :first_active_at %>
 
 <%= form.govuk_text_field :operating_name, width: "full", label: { size: "s", text: " Operating name" },
                                            hint: { text: "The name the provider uses in public facing activities" } %>

--- a/app/views/providers/first_become_active/new.html.erb
+++ b/app/views/providers/first_become_active/new.html.erb
@@ -5,7 +5,7 @@
       ) %>
 <% end %>
 
-<%= form_for @form, url: new_provider_first_become_active_path do |form| %>
+<%= form_for @form, url: new_provider_first_become_active_path(goto: params[:goto]) do |form| %>
   <% page_data(title: "When did the provider first become active?", subtitle: "Add provider", header: false, error: @form.errors.present?) %>
 
   <%= content_for(:page_alerts) { form.govuk_error_summary } %>

--- a/app/views/providers/first_become_active/new.html.erb
+++ b/app/views/providers/first_become_active/new.html.erb
@@ -1,0 +1,27 @@
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+        text: "Back",
+        href: back_path,
+      ) %>
+<% end %>
+
+<%= form_for @form, url: new_provider_first_become_active_path do |form| %>
+  <% page_data(title: "When did the provider first become active?", subtitle: "Add provider", header: false, error: @form.errors.present?) %>
+
+  <%= content_for(:page_alerts) { form.govuk_error_summary } %>
+
+  <%= form.hidden_field :onboarded_at %>
+
+  <%= form.govuk_radio_buttons_fieldset(:first_active_at_date_choice, legend: { text: "When did the provider first become active?" }, caption: { text: "Add provider" }) do %>
+    <%= form.govuk_radio_button :first_active_at_date_choice, :same, label: { text: "Same as onboarded at date, #{@form.onboarded_at.to_fs(:govuk)}" }, link_errors: true %>
+    <%= form.govuk_radio_button :first_active_at_date_choice, :other, label: { text: "Another day" } do %>
+      <%= form.govuk_date_field :first_active_at_date, legend: { text: "On what date?", size: "s" }, hint: { text: "For example, 3 12 2020" } %>
+      <% end %>
+  <% end %>
+
+  <%= form.govuk_submit %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to("Cancel", providers_path) %>
+</p>

--- a/app/views/providers/is_the_provider_accredited/new.html.erb
+++ b/app/views/providers/is_the_provider_accredited/new.html.erb
@@ -1,0 +1,25 @@
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+        text: "Back",
+        href: back_path,
+      ) %>
+<% end %>
+
+<%= form_for @form, url: new_provider_is_the_provider_accredited_path do |form| %>
+  <% page_data(title: "Is the provider accredited?", subtitle: "Add provider", header: false, error: @form.errors.present?) %>
+
+  <%= content_for(:page_alerts) { form.govuk_error_summary } %>
+
+  <%= form.govuk_fieldset legend: { text: "Is the provider accredited?" }, caption: { text: "Add provider" } do %>
+
+    <%= form.govuk_collection_radio_buttons(:accreditation_status, form.object.accreditation_status_options_for_radios,
+                                            :key,
+                                            :value, legend: nil) %>
+
+    <%= form.govuk_submit %>
+  <% end %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to("Cancel", providers_path) %>
+</p>

--- a/app/views/providers/onboarding/new.html.erb
+++ b/app/views/providers/onboarding/new.html.erb
@@ -5,7 +5,7 @@
       ) %>
 <% end %>
 
-<%= form_for @form, url: new_provider_onboarding_path do |form| %>
+<%= form_for @form, url: new_provider_onboarding_path(goto: params[:goto]) do |form| %>
   <% page_data(title: "When did the provider onboard?", subtitle: "Add provider", header: false, error: @form.errors.present?) %>
 
   <%= content_for(:page_alerts) { form.govuk_error_summary } %>

--- a/app/views/providers/onboarding/new.html.erb
+++ b/app/views/providers/onboarding/new.html.erb
@@ -6,18 +6,19 @@
 <% end %>
 
 <%= form_for @form, url: new_provider_onboarding_path do |form| %>
-  <% page_data(title: "Is the provider accredited?", subtitle: "Add provider", header: false, error: @form.errors.present?) %>
+  <% page_data(title: "When did the provider onboard?", subtitle: "Add provider", header: false, error: @form.errors.present?) %>
 
   <%= content_for(:page_alerts) { form.govuk_error_summary } %>
 
-  <%= form.govuk_fieldset legend: { text: "Is the provider accredited?" }, caption: { text: "Add provider" } do %>
-
-    <%= form.govuk_collection_radio_buttons(:accreditation_status, form.object.accreditation_status_options_for_radios,
-                                            :key,
-                                            :value, legend: nil) %>
-
-    <%= form.govuk_submit %>
+  <%= form.govuk_radio_buttons_fieldset(:onboarded_at_date_choice, legend: { text: "When did the provider onboard?" }, caption: { text: "Add provider" }) do %>
+    <%= form.govuk_radio_button :onboarded_at_date_choice, :today, label: { text: "Today" }, link_errors: true %>
+    <%= form.govuk_radio_button :onboarded_at_date_choice, :yesterday, label: { text: "Yesterday" } %>
+    <%= form.govuk_radio_button :onboarded_at_date_choice, :other, label: { text: "Another day" } do %>
+      <%= form.govuk_date_field :onboarded_at_date, legend: { text: "On what date?", size: "s" }, hint: { text: "For example, 3 12 2020" } %>
+      <% end %>
   <% end %>
+  <%= form.govuk_submit %>
+
 <% end %>
 
 <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,10 @@ en:
               blank: "Select when the provider was onboarded"
             onboarded_at_date:
               blank: "Enter the onboarding date"
+            first_active_at_date_choice:
+              blank: "Select when the provider was first become active"
+            first_active_at_date:
+              blank: "Enter the first active date"
             accreditation_status:
               invalid_provider_type: "School cannot be accredited"
               blank: "Select if the provider is accredited"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,7 +129,7 @@ en:
             onboarded_at_date:
               blank: "Enter onboarded date"
             first_active_at_date_choice:
-              blank: "Select when the provider was first become active"
+              blank: "Select when the provider first became active"
             first_active_at_date:
               blank: "Enter first active date"
             accreditation_status:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,10 @@ en:
               blank: "Please select an address"
         provider:
           attributes:
+            onboarded_at_date_choice:
+              blank: "Select when the provider was onboarded"
+            onboarded_at_date:
+              blank: "Enter the onboarding date"
             accreditation_status:
               invalid_provider_type: "School cannot be accredited"
               blank: "Select if the provider is accredited"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,7 @@ en:
             first_active_at_date_choice:
               blank: "Select when the provider was first become active"
             first_active_at_date:
-              blank: "Enter the first active date"
+              blank: "Enter first active date"
             accreditation_status:
               invalid_provider_type: "School cannot be accredited"
               blank: "Select if the provider is accredited"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,7 +127,7 @@ en:
             onboarded_at_date_choice:
               blank: "Select when the provider was onboarded"
             onboarded_at_date:
-              blank: "Enter the onboarding date"
+              blank: "Enter onboarded date"
             first_active_at_date_choice:
               blank: "Select when the provider was first become active"
             first_active_at_date:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,11 @@ Rails.application.routes.draw do
   scope path: "/providers/new", as: :new_provider, module: :providers do
     get "", to: "onboarding#new", as: :onboarding
     post "", to: "onboarding#create"
+    get "first-become-active", to: "first_become_active#new", as: :first_become_active
+    post "first-become-active", to: "first_become_active#create"
+
+    get "is-the-provider-accredited", to: "is_the_provider_accredited#new", as: :is_the_provider_accredited
+    post "is-the-provider-accredited", to: "is_the_provider_accredited#create"
 
     get "type", to: "type#new", as: :type
     post "type", to: "type#create"

--- a/spec/features/end_to_end/providers/back_button_navigation_spec.rb
+++ b/spec/features/end_to_end/providers/back_button_navigation_spec.rb
@@ -158,12 +158,75 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
   end
 
   context "Change flow (from Check page with goto=confirm)" do
+    scenario "Change onboarded date - back unwinds to check page" do
+      given_i_am_an_authenticated_user
+      and_i_have_completed_provider_creation_to_check_page
+
+      # Click change on onboarded date
+      click_on("Change onboarded date")
+      then_i_should_be_on_the_onboarding_page
+      expect(page.current_url).to include("goto=confirm")
+
+      # Back should go to check, not onboarding
+      when_i_click_the_back_link
+      then_i_should_be_on_the_check_page
+    end
+
+    scenario "Change onboarded date - continue returns to check page" do
+      given_i_am_an_authenticated_user
+      and_i_have_completed_provider_creation_to_check_page
+
+      # Click change on onboarded date
+      click_on("Change onboarded date")
+      then_i_should_be_on_the_onboarding_page
+      expect(page.current_url).to include("goto=confirm")
+
+      # Change selection and continue should return to check
+      choose "Yesterday"
+      when_i_click_on("Continue")
+      then_i_should_be_on_the_check_page
+    end
+
+    scenario "Change first active date - back unwinds to check page" do
+      given_i_am_an_authenticated_user
+      and_i_have_completed_provider_creation_to_check_page
+
+      # Click change on first active date
+      click_on("Change first active date")
+      then_i_should_be_on_the_first_become_active_page
+      expect(page.current_url).to include("goto=confirm")
+
+      # Back should go to check, not onboarding
+      when_i_click_the_back_link
+      then_i_should_be_on_the_check_page
+    end
+
+    scenario "Change first active date - continue returns to check page" do
+      given_i_am_an_authenticated_user
+      and_i_have_completed_provider_creation_to_check_page
+
+      # Click change on first active date
+      click_on("Change first active date")
+      then_i_should_be_on_the_first_become_active_page
+      expect(page.current_url).to include("goto=confirm")
+
+      # Change selection and continue should return to check
+      choose("Another day")
+      option = 1.month.ago
+
+      fill_in "Day", with: option.day
+      fill_in "Month", with: option.month
+      fill_in "Year", with: option.year
+      when_i_click_on("Continue")
+      then_i_should_be_on_the_check_page
+    end
+
     scenario "Change provider type - back unwinds to check page" do
       given_i_am_an_authenticated_user
       and_i_have_completed_provider_creation_to_check_page
 
       # Click change on provider type
-      click_on("Change", match: :first) # Use click_on directly to support options
+      click_on("Change provider type")
       then_i_should_be_on_the_type_page
       expect(page.current_url).to include("goto=confirm")
 
@@ -177,7 +240,7 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
       and_i_have_completed_provider_creation_to_check_page
 
       # Click change on provider type
-      click_on("Change", match: :first)
+      click_on("Change provider type")
       then_i_should_be_on_the_type_page
       expect(page.current_url).to include("goto=confirm")
 
@@ -346,8 +409,16 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
     expect(page).to have_current_path("/providers/new/first-become-active", ignore_query: true)
   end
 
+  def then_i_should_be_on_the_first_become_active_page
+    expect(page).to have_current_path("/providers/new/first-become-active", ignore_query: true)
+  end
+
   def then_i_should_be_on_the_is_the_provider_accredited_page
     expect(page).to have_current_path("/providers/new/is-the-provider-accredited", ignore_query: true)
+  end
+
+  def then_i_should_be_on_the_onboarding_page
+    expect(page).to have_current_path("/providers/new", ignore_query: true)
   end
 
   def then_i_should_be_on_the_type_page

--- a/spec/features/end_to_end/providers/back_button_navigation_spec.rb
+++ b/spec/features/end_to_end/providers/back_button_navigation_spec.rb
@@ -34,6 +34,17 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
     scenario "Unaccredited provider - back buttons go to previous step in journey" do
       given_i_am_an_authenticated_user
       when_i_start_creating_a_provider
+
+      # Now on onboarding page
+      then_i_should_be_on_the_onboarding_page
+      and_i_answer_the_onboarding_question_as("Today")
+
+      # Now on first become active
+      then_i_should_be_on_the_first_become_active_page
+      and_i_answer_the_first_become_active_question_as("Same as onboarded at date,")
+
+      # Now on is the provider accredited page
+      then_i_should_be_on_the_is_the_provider_accredited_page
       and_i_answer_the_accreditation_question_as("No")
 
       # Now on Type page - select type but don't continue yet to test back button
@@ -49,7 +60,14 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
 
       # Test back to onboarding
       when_i_click_the_back_link
+      then_i_should_be_on_the_is_the_provider_accredited_page
+
+      when_i_click_the_back_link
+      then_i_should_be_on_the_first_become_active_page
+      when_i_click_the_back_link
       then_i_should_be_on_the_onboarding_page
+      and_i_answer_the_onboarding_question_as("Today")
+      and_i_answer_the_first_become_active_question_as("Same as onboarded at date,")
       and_my_accreditation_answer_should_be_selected("No")
 
       # Go forward through journey again
@@ -86,6 +104,8 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
     scenario "Accredited provider - back from address goes to accreditation" do
       given_i_am_an_authenticated_user
       when_i_start_creating_a_provider
+      and_i_answer_the_onboarding_question_as("Today")
+      and_i_answer_the_first_become_active_question_as("Same as onboarded at date,")
       and_i_answer_the_accreditation_question_as("Yes")
       and_i_select_provider_type(:scitt)
       and_i_fill_in_provider_details
@@ -256,6 +276,16 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
     click_on("Add provider")
   end
 
+  def and_i_answer_the_onboarding_question_as(option)
+    choose(option)
+    click_on("Continue")
+  end
+
+  def and_i_answer_the_first_become_active_question_as(option)
+    choose(option)
+    click_on("Continue")
+  end
+
   def and_i_answer_the_accreditation_question_as(answer)
     @accreditation_answer = answer
     @accreditation_status = answer == "Yes" ? "accredited" : "unaccredited"
@@ -312,6 +342,14 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
     expect(page).to have_current_path("/providers/new", ignore_query: true)
   end
 
+  def then_i_should_be_on_the_first_become_active_page
+    expect(page).to have_current_path("/providers/new/first-become-active", ignore_query: true)
+  end
+
+  def then_i_should_be_on_the_is_the_provider_accredited_page
+    expect(page).to have_current_path("/providers/new/is-the-provider-accredited", ignore_query: true)
+  end
+
   def then_i_should_be_on_the_type_page
     expect(page).to have_current_path("/providers/new/type", ignore_query: true)
   end
@@ -366,6 +404,8 @@ RSpec.feature "Provider Creation - Back Button Navigation" do
 
   # Helpers for address search/select flow
   def and_i_complete_provider_details_as_unaccredited
+    and_i_answer_the_onboarding_question_as("Today")
+    and_i_answer_the_first_become_active_question_as("Same as onboarded at date,")
     and_i_answer_the_accreditation_question_as("No")
     and_i_select_provider_type(:hei)
     and_i_fill_in_provider_details

--- a/spec/features/end_to_end/providers/creating_provider_spec.rb
+++ b/spec/features/end_to_end/providers/creating_provider_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Add Provider" do
-  shared_examples "adding a provider with accreditation status" do |accreditation_status|
+  shared_examples "adding a provider with accreditation status" do |accreditation_status, onboarded_at, first_become_active|
     let(:address_line_1) { Faker::Address.street_address }
     let(:address_line_2) { Faker::Address.secondary_address }
     let(:town_or_city) { Faker::Address.city }
@@ -12,9 +12,12 @@ RSpec.feature "Add Provider" do
       allow(Addresses::GeocodeService).to receive(:call).and_return({ latitude: 51.503396, longitude: -0.127764 })
     end
 
-    scenario "User can add a new provider with accreditation status: #{accreditation_status}" do
+    scenario "User can add a new provider with accreditation status:
+      #{accreditation_status}, onboarded_at: #{onboarded_at}, first_become_active: #{first_become_active}" do
       given_i_am_an_authenticated_user
       when_i_navigate_to_the_add_provider_page
+      and_i_fill_out_the_onboarding_details(onboarded_at)
+      and_i_fill_out_the_first_become_active_details(first_become_active)
       and_i_fill_out_the_provider_form_with_valid_details(accreditation_status:)
       and_i_am_on_the_check_answers_page
       then_the_address_should_be_displayed_on_check_answers
@@ -27,6 +30,68 @@ RSpec.feature "Add Provider" do
     def when_i_navigate_to_the_add_provider_page
       visit providers_path
       click_on("Add provider")
+    end
+
+    def and_i_fill_out_the_onboarding_details(option)
+      and_i_am_taken_to("/providers/new")
+
+      and_i_can_see_the_title("When did the provider onboard? - Add provider - Register of training providers - GOV.UK")
+      and_i_do_not_see_error_summary
+
+      and_i_click_on("Continue")
+
+      and_i_can_see_the_error_summary("Select when the provider was onboarded")
+      and_i_can_see_the_title("Error: When did the provider onboard? - Add provider - Register of training providers - GOV.UK")
+
+      case option
+      when String
+        choose(option)
+        click_on("Continue")
+      when Time, ActiveSupport::TimeWithZone
+        choose("Another day")
+
+        click_on("Continue")
+
+        and_i_can_see_the_error_summary("Enter onboarded date")
+        and_i_can_see_the_title("Error: When did the provider onboard? - Add provider - Register of training providers - GOV.UK")
+
+        fill_in "Day", with: option.day
+        fill_in "Month", with: option.month
+        fill_in "Year", with: option.year
+
+        click_on("Continue")
+      end
+    end
+
+    def and_i_fill_out_the_first_become_active_details(option)
+      and_i_am_taken_to("/providers/new/first-become-active")
+
+      and_i_can_see_the_title("When did the provider first become active? - Add provider - Register of training providers - GOV.UK")
+      and_i_do_not_see_error_summary
+
+      and_i_click_on("Continue")
+
+      and_i_can_see_the_error_summary("Select when the provider was first become active")
+      and_i_can_see_the_title("Error: When did the provider first become active? - Add provider - Register of training providers - GOV.UK")
+
+      case option
+      when String
+        choose(option)
+        click_on("Continue")
+      when Time, ActiveSupport::TimeWithZone
+        choose("Another day")
+
+        click_on("Continue")
+
+        and_i_can_see_the_error_summary("Enter first active date")
+        and_i_can_see_the_title("Error: When did the provider first become active? - Add provider - Register of training providers - GOV.UK")
+
+        fill_in "Day", with: option.day
+        fill_in "Month", with: option.month
+        fill_in "Year", with: option.year
+
+        click_on("Continue")
+      end
     end
 
     def and_i_fill_out_the_provider_form_with_valid_details(accreditation_status:)
@@ -170,7 +235,7 @@ RSpec.feature "Add Provider" do
     end
 
     def and_i_answer_the_accreditation_question(select_if_the_provider_is_accredited:)
-      and_i_am_taken_to("/providers/new")
+      and_i_am_taken_to("/providers/new/is-the-provider-accredited")
 
       and_i_can_see_the_title("Is the provider accredited? - Add provider - Register of training providers - GOV.UK")
       and_i_do_not_see_error_summary
@@ -247,6 +312,7 @@ RSpec.feature "Add Provider" do
     end
   end
 
-  include_examples "adding a provider with accreditation status", :accredited
-  include_examples "adding a provider with accreditation status", :unaccredited
+  include_examples "adding a provider with accreditation status", :accredited, "Today", "Same as onboarded at date"
+  include_examples "adding a provider with accreditation status", :unaccredited, "Yesterday", "Same as onboarded at date"
+  include_examples "adding a provider with accreditation status", :unaccredited, 2.weeks.ago, 1.week.ago
 end

--- a/spec/features/end_to_end/providers/creating_provider_spec.rb
+++ b/spec/features/end_to_end/providers/creating_provider_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Add Provider" do
 
       and_i_click_on("Continue")
 
-      and_i_can_see_the_error_summary("Select when the provider was first become active")
+      and_i_can_see_the_error_summary("Select when the provider first became active")
       and_i_can_see_the_title("Error: When did the provider first become active? - Add provider - Register of training providers - GOV.UK")
 
       case option

--- a/spec/forms/providers/first_become_active_form_spec.rb
+++ b/spec/forms/providers/first_become_active_form_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe Providers::FirstBecomeActiveForm do
+  subject(:form) { described_class.new(attributes) }
+
+  let(:onboarded_at) { Date.new(2024, 9, 1) }
+
+  let(:base_attributes) do
+    {
+      onboarded_at:
+    }
+  end
+
+  let(:attributes) { base_attributes }
+
+  describe ".model_name" do
+    it "returns Provider" do
+      expect(described_class.model_name.name).to eq("Provider")
+    end
+  end
+
+  describe ".i18n_scope" do
+    it { expect(described_class.i18n_scope).to eq(:activerecord) }
+  end
+
+  describe ".additional_params" do
+    it do
+      expect(described_class.additional_params)
+        .to eq([["onboarded_at", "onboarded_at"]])
+    end
+  end
+
+  describe "#predefined_dates" do
+    it do
+      expect(form.predefined_dates).to eq(
+        "same" => onboarded_at
+      )
+    end
+  end
+
+  describe "validations" do
+    context "without a choice" do
+      it "is invalid" do
+        form.valid?
+
+        expect(form.errors[:first_active_at_date_choice]).to be_present
+      end
+    end
+
+    context "when the choice is same" do
+      let(:attributes) do
+        base_attributes.merge(
+          first_active_at_date_choice: "same"
+        )
+      end
+
+      it { expect(form).to be_valid }
+    end
+
+    context "when the choice is other" do
+      let(:attributes) do
+        base_attributes.merge(
+          first_active_at_date_choice: "other"
+        )
+      end
+
+      context "without a date" do
+        it "is invalid" do
+          form.valid?
+
+          expect(form.errors[:first_active_at_date]).to be_present
+        end
+      end
+
+      context "with a date" do
+        let(:attributes) do
+          super().merge(
+            first_active_at_date_day: "15",
+            first_active_at_date_month: "10",
+            first_active_at_date_year: "2024"
+          )
+        end
+
+        it { expect(form).to be_valid }
+      end
+    end
+  end
+
+  describe "#first_active_at" do
+    context "when the choice is same" do
+      let(:attributes) do
+        base_attributes.merge(
+          first_active_at_date_choice: "same"
+        )
+      end
+
+      it "returns the onboarded_at date" do
+        expect(form.first_active_at).to eq(onboarded_at)
+      end
+    end
+
+    context "when the choice is other" do
+      let(:attributes) do
+        base_attributes.merge(
+          first_active_at_date_choice: "other",
+          first_active_at_date_day: "1",
+          first_active_at_date_month: "11",
+          first_active_at_date_year: "2024"
+        )
+      end
+
+      it "returns the entered date" do
+        form.valid?
+
+        expect(form.first_active_at).to eq(Date.new(2024, 11, 1))
+      end
+    end
+  end
+end

--- a/spec/forms/providers/onboarding_form_spec.rb
+++ b/spec/forms/providers/onboarding_form_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe Providers::OnboardingForm do
+  subject(:form) { described_class.new }
+
+  describe "validations" do
+    it "requires a choice" do
+      form.onboarded_at_date_choice = nil
+
+      expect(form).not_to be_valid
+      expect(form.errors[:onboarded_at_date_choice]).to be_present
+    end
+
+    it "does not require a date when choice is not 'other'" do
+      form.onboarded_at_date_choice = "today"
+
+      expect(form).to be_valid
+    end
+
+    it "requires a date when choice is 'other'" do
+      form.onboarded_at_date_choice = "other"
+
+      expect(form).not_to be_valid
+      expect(form.errors[:onboarded_at_date]).to be_present
+    end
+  end
+
+  describe "#onboarded_at" do
+    before do
+      allow(form).to receive(:predefined_dates).and_return(
+        "today" => Date.new(2026, 1, 1),
+        "yesterday" => Date.new(2025, 12, 31)
+      )
+    end
+
+    context "when choice is predefined" do
+      it "returns predefined date" do
+        form.onboarded_at_date_choice = "today"
+
+        expect(form.onboarded_at).to eq(Date.new(2026, 1, 1))
+      end
+    end
+
+    context "when choice is other" do
+      it "builds date from components" do
+        form.onboarded_at_date_choice = "other"
+        form.onboarded_at_date_day = 17
+        form.onboarded_at_date_month = 6
+        form.onboarded_at_date_year = 2025
+
+        form.send(:convert_date_components)
+
+        expect(form.onboarded_at).to eq(Date.new(2025, 6, 17))
+      end
+    end
+  end
+
+  describe "before_validation callback" do
+    it "converts date components into a date" do
+      form.onboarded_at_date_choice = "other"
+      form.onboarded_at_date_day = 17
+      form.onboarded_at_date_month = 6
+      form.onboarded_at_date_year = 2025
+
+      form.valid?
+
+      expect(form.onboarded_at_date).to eq(Date.new(2025, 6, 17))
+    end
+  end
+
+  describe ".model_name" do
+    it "returns Provider for form builder compatibility" do
+      expect(described_class.model_name.to_s).to eq("Provider")
+    end
+  end
+end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -101,8 +101,6 @@ RSpec.describe ProviderHelper, type: :helper do
 
     it "returns the expected rows and with 'Not entered' where applicable" do
       expect(helper.provider_rows(provider, change_path, change_provider_type_path:)).to eq([
-        { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
-        { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
         {
           key: { text: "Operating name" },
           value: { text: provider.operating_name },
@@ -133,16 +131,27 @@ RSpec.describe ProviderHelper, type: :helper do
 
     context "when all values are present" do
       let(:provider) { build_stubbed(:provider, :scitt) }
-      let(:change_provider_type_path) { "/providers/type/edit" }
+      let(:change_provider_type_path) { "/providers/new/type" }
+      let(:change_provider_onboarding_path) { "/providers/new" }
+      let(:change_provider_first_become_active_path) { "/providers/new/first-become-active" }
 
       it "returns the expected rows without 'Not entered'" do
-        expect(helper.provider_rows(provider, change_path, change_provider_type_path:)).to eq([
-          { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
-          { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
+        expect(helper.provider_rows(provider, change_path, change_provider_type_path:, change_provider_onboarding_path:, change_provider_first_become_active_path:)).to eq([
+          {
+            key: { text: "Onboard at" },
+            value: { text: Time.zone.today.to_fs(:govuk) },
+            actions: [{ href: change_provider_onboarding_path, visually_hidden_text: "onboarded date" }]
+          },
+          {
+            key: { text: "First active at" },
+            value: { text: Time.zone.today.to_fs(:govuk) },
+            actions: [{ href: change_provider_first_become_active_path, visually_hidden_text: "first active date" }]
+          },
           {
             key: { text: "Provider type" },
             value: { text: provider.provider_type_label },
             actions: [{ href: change_provider_type_path, visually_hidden_text: "provider type" }]
+
           },
           {
             key: { text: "Operating name" },

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -101,6 +101,8 @@ RSpec.describe ProviderHelper, type: :helper do
 
     it "returns the expected rows and with 'Not entered' where applicable" do
       expect(helper.provider_rows(provider, change_path, change_provider_type_path:)).to eq([
+        { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
+        { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
         {
           key: { text: "Operating name" },
           value: { text: provider.operating_name },
@@ -135,6 +137,8 @@ RSpec.describe ProviderHelper, type: :helper do
 
       it "returns the expected rows without 'Not entered'" do
         expect(helper.provider_rows(provider, change_path, change_provider_type_path:)).to eq([
+          { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
+          { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
           {
             key: { text: "Provider type" },
             value: { text: provider.provider_type_label },

--- a/spec/models/concerns/govuk_date_components_spec.rb
+++ b/spec/models/concerns/govuk_date_components_spec.rb
@@ -1,0 +1,193 @@
+require "rails_helper"
+
+RSpec.describe GovukDateComponents do
+  let(:described_class_with_choice) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include GovukDateComponents
+
+      has_date_components_with_choice :start_date
+
+      attr_accessor :start_date_choice
+
+      def attributes
+        {
+          "start_date" => start_date,
+          "start_date_day" => start_date_day,
+          "start_date_month" => start_date_month,
+          "start_date_year" => start_date_year,
+          "start_date_choice" => start_date_choice
+        }
+      end
+    end
+  end
+
+  let(:described_class_without_choice) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include GovukDateComponents
+
+      has_date_components :start_date
+
+      def attributes
+        {
+          "start_date" => start_date,
+          "start_date_day" => start_date_day,
+          "start_date_month" => start_date_month,
+          "start_date_year" => start_date_year
+        }
+      end
+    end
+  end
+
+  describe ".has_date_components" do
+    it "defines date attributes" do
+      klass = described_class_without_choice
+
+      expect(klass::DATE_FIELDS).to eq([:start_date])
+      expect(klass::PARAM_CONVERSION).to include(
+        "start_date(3i)" => "start_date_day",
+        "start_date(2i)" => "start_date_month",
+        "start_date(1i)" => "start_date_year"
+      )
+      expect(klass::CHOICE).to eq(false)
+    end
+  end
+
+  describe ".has_date_components_with_choice" do
+    it "defines date attributes including choice field" do
+      klass = described_class_with_choice
+
+      expect(klass::DATE_FIELDS).to eq([:start_date])
+      expect(klass::PARAM_CONVERSION).to include(
+        "start_date_choice" => "start_date_choice"
+      )
+      expect(klass::CHOICE).to eq(true)
+    end
+  end
+
+  describe "#build_date_from_components (via public behaviour)" do
+    let(:form) { described_class_without_choice.new }
+
+    it "builds a valid date" do
+      form.start_date_day = 17
+      form.start_date_month = 6
+      form.start_date_year = 2025
+
+      form.send(:convert_date_components)
+
+      expect(form.start_date).to eq(Date.new(2025, 6, 17))
+    end
+
+    it "returns nil for invalid date" do
+      form.start_date_day = 31
+      form.start_date_month = 2
+      form.start_date_year = 2025
+
+      form.send(:convert_date_components)
+
+      expect(form.start_date).to be_nil
+    end
+  end
+
+  describe "#resolve_date_from_choice" do
+    let(:form) { described_class_with_choice.new }
+
+    before do
+      allow(form).to receive(:predefined_dates).and_return(
+        "today" => Date.new(2026, 1, 1)
+      )
+    end
+
+    it "returns predefined date when choice matches" do
+      form.start_date_choice = "today"
+
+      expect(form.resolve_date_from_choice(:start_date)).to eq(Date.new(2026, 1, 1))
+    end
+
+    it "falls back to components when choice is 'other'" do
+      form.start_date_choice = "other"
+
+      form.start_date_day = 17
+      form.start_date_month = 6
+      form.start_date_year = 2025
+
+      expect(form.resolve_date_from_choice(:start_date)).to eq(Date.new(2025, 6, 17))
+    end
+
+    it "falls back to components when choice is blank" do
+      form.start_date_choice = nil
+
+      form.start_date_day = 17
+      form.start_date_month = 6
+      form.start_date_year = 2025
+
+      expect(form.resolve_date_from_choice(:start_date)).to eq(Date.new(2025, 6, 17))
+    end
+  end
+
+  describe "#extract_date_components_from" do
+    let(:form) { described_class_without_choice.new }
+
+    it "extracts date components from source object" do
+      source = Struct.new(:start_date).new(Date.new(2025, 6, 17))
+
+      expect(form.extract_date_components_from(source)).to eq(
+        start_date: Date.new(2025, 6, 17),
+        start_date_day: 17,
+        start_date_month: 6,
+        start_date_year: 2025
+      )
+    end
+
+    it "handles nil dates" do
+      source = Struct.new(:start_date).new(nil)
+
+      expect(form.extract_date_components_from(source)).to eq(
+        start_date: nil
+      )
+    end
+  end
+
+  describe "#serializable_hash" do
+    context "without choice" do
+      let(:form) { described_class_without_choice.new }
+
+      before do
+        form.start_date = Date.new(2025, 6, 17)
+        form.start_date_day = 17
+        form.start_date_month = 6
+        form.start_date_year = 2025
+      end
+
+      it "includes date and components" do
+        expect(form.serializable_hash).to include(
+          "start_date" => Date.new(2025, 6, 17),
+          "start_date_day" => 17,
+          "start_date_month" => 6,
+          "start_date_year" => 2025
+        )
+      end
+    end
+
+    context "with choice" do
+      let(:form) { described_class_with_choice.new }
+
+      before do
+        form.start_date = Date.new(2025, 6, 17)
+        form.start_date_day = 17
+        form.start_date_month = 6
+        form.start_date_year = 2025
+        form.start_date_choice = "today"
+      end
+
+      it "includes choice field in serialization" do
+        expect(form.serializable_hash).to include(
+          "start_date_choice" => "today"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Add a provider journey when did the provider onboard

### Changes proposed in this pull request
Add a provider journey for when did the provider onboard and first become active

### Guidance to review
From the listing of providers, click on the `Add provider` button.
Go thro the creation journey,use the back links, use the change links

#### Screensnots
##### When did the provider onboard?
<img width="3840" height="2573" alt="image" src="https://github.com/user-attachments/assets/f2f5e794-8a3e-4087-b90b-fe19b5f6c93a" />

<img width="3840" height="2573" alt="image" src="https://github.com/user-attachments/assets/ea2360c1-5f7b-4a26-a53a-559a6fb2fff2" />

<img width="3840" height="2573" alt="image" src="https://github.com/user-attachments/assets/1a354559-5349-471b-b42c-a8ad734b8d57" />

##### When did the provider first become active?

<img width="3840" height="2573" alt="image" src="https://github.com/user-attachments/assets/b8e66908-5243-4dad-8e48-b8aa1e9c24d4" />

<img width="3840" height="2573" alt="image" src="https://github.com/user-attachments/assets/a01edf7b-9514-467c-a0c3-30016eb2d99c" />

<img width="3840" height="2573" alt="image" src="https://github.com/user-attachments/assets/47b55255-5138-4760-82ec-77e3fb41c7bd" />

###### Check your answers page
<img width="1720" height="1985" alt="image" src="https://github.com/user-attachments/assets/b44dfed2-378b-47d1-930d-885ec82063bd" />
