### PR TITLE
[481] - display active academic years

### DIFF
--- a/app/helpers/academic_year_helper.rb
+++ b/app/helpers/academic_year_helper.rb
@@ -1,9 +1,15 @@
 module AcademicYearHelper
-  def academic_years_row(academic_years, use_details)
+  def academic_years_row(academic_years, use_details, active)
     {
-      key: { text: "Academic years" },
+      key: { text: academic_years_row_key_text(active) },
       value: { text: academic_years_html(academic_years, use_details) }
     }
+  end
+
+  def academic_years_row_key_text(active)
+    return "Active academic years" if active
+
+    "Academic years"
   end
 
   def academic_years_html(academic_years, use_details)

--- a/app/helpers/partnership_helper.rb
+++ b/app/helpers/partnership_helper.rb
@@ -45,7 +45,7 @@ module PartnershipHelper
     end
     rows << dates_row
 
-    years_row = academic_years_row(partnership.academic_years, false)
+    years_row = academic_years_row(partnership.academic_years, false, false)
     if change_paths[:academic_years].present?
       years_row[:actions] = [{ href: change_paths[:academic_years], visually_hidden_text: "academic years" }]
     end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -25,8 +25,8 @@ module ProviderHelper
                             value: {
                               text: provider.first_active_at.to_fs(:govuk)
                             } }] unless hide_first_active_at
-    summary_card_rows += [academic_years_row(provider.academic_years.order(duration: :desc),
-                                             use_details_for_academic_years_row)]
+    summary_card_rows += [academic_years_row(provider.active_academic_years.order(duration: :desc),
+                                             use_details_for_academic_years_row, true)]
 
     unless hide_inactive_periods
       summary_card_rows += [{ key: { text: "Inactive periods" },
@@ -132,7 +132,6 @@ module ProviderHelper
       "UK provider reference number (UKPRN)" => "UK provider reference number (UKPRN)",
       "Unique reference number (URN)" => "unique reference number (URN)",
       "Provider code" => "provider code",
-      "Academic years" => "academic years"
     }
 
     rows.each do |row|

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -152,7 +152,7 @@ class Provider < ApplicationRecord
   end
 
   def active_academic_years
-academic_years = AcademicYear.where("lower(duration) >= ? AND upper(duration) <= ?", onboarded_at, Date.current)
+    academic_years = AcademicYear.where("lower(duration) >= ? AND lower(duration) < ?", first_active_at, Date.current)
 
     inactive_periods.each do |period|
       academic_years = if period["end_date"].nil?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -151,6 +151,23 @@ class Provider < ApplicationRecord
     accrediting_provider_partnerships.or(accredited_provider_partnerships)
   end
 
+  def active_academic_years
+    academic_years = AcademicYear.where("lower(duration) >= ?", onboarded_at)
+
+    inactive_periods.each do |period|
+      academic_years = if period["end_date"].nil?
+                         academic_years.where.not("duration @> ?::date", period["start_date"]).where.not(
+                           "upper(duration) >= ?", period["start_date"]
+                         )
+                       else
+                         academic_years.where.not("duration @> ANY (ARRAY[?]::date[])",
+                                                  [period["start_date"], period["end_date"]])
+                       end
+    end
+
+    academic_years
+  end
+
 private
 
   def update_searchable

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -152,7 +152,7 @@ class Provider < ApplicationRecord
   end
 
   def active_academic_years
-    academic_years = AcademicYear.where("lower(duration) >= ?", onboarded_at)
+academic_years = AcademicYear.where("lower(duration) >= ? AND upper(duration) <= ?", onboarded_at, Date.current)
 
     inactive_periods.each do |period|
       academic_years = if period["end_date"].nil?

--- a/spec/helpers/academic_year_helper_spec.rb
+++ b/spec/helpers/academic_year_helper_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe AcademicYearHelper, type: :helper do
   describe "#academic_years_row" do
-    subject { helper.academic_years_row(academic_years, false) }
+    subject { helper.academic_years_row(academic_years, false, active) }
+    let(:active) { false }
 
     let(:academic_years) do
       [
@@ -11,9 +12,22 @@ RSpec.describe AcademicYearHelper, type: :helper do
       ]
     end
 
-    it "returns a hash with key and value" do
-      expect(subject).to include(:key, :value)
-      expect(subject[:key][:text]).to eq("Academic years")
+    context "displaying active academic years" do
+      let(:active) { true }
+
+      it "returns a hash with key and value" do
+        expect(subject).to include(:key, :value)
+        expect(subject[:key][:text]).to eq("Active academic years")
+      end
+    end
+
+    context "displaying academic years" do
+      let(:active) { false }
+
+      it "returns a hash with key and value" do
+        expect(subject).to include(:key, :value)
+        expect(subject[:key][:text]).to eq("Academic years")
+      end
     end
 
     it "renders a GOV.UK bullet list" do

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -2,8 +2,10 @@ require "rails_helper"
 
 RSpec.describe ProviderHelper, type: :helper do
   let(:current_academic_year) { AcademicYearCalculator.current_academic_year }
+  let(:onboarded_at) { 1.year.ago }
+
   describe "#provider_summary_cards" do
-    let(:provider) { create(:provider, legal_name: nil, operating_name: "School of learning", urn: "50000") }
+    let(:provider) { create(:provider, legal_name: nil, operating_name: "School of learning", urn: "50000", onboarded_at: onboarded_at, first_active_at: onboarded_at) }
     let(:providers) { [provider] }
 
     it "returns the expected not entered hash" do
@@ -27,7 +29,7 @@ RSpec.describe ProviderHelper, type: :helper do
         { key: { text: "Accreditation status" }, value: { text: provider.accreditation_status_label } },
         { key: { text: "Operating name" }, value: { text: provider.operating_name } },
         { key: { text: "Legal name" }, value: { text: "Not entered", classes: "govuk-hint" } },
-        { key: { text: "Active academic years" }, value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" } },
+        { key: { text: "Active academic years" }, value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year} to #{current_academic_year + 1} - current</li></ul>" } },
       ])
     end
 
@@ -45,7 +47,7 @@ RSpec.describe ProviderHelper, type: :helper do
     end
 
     context "when provider is archived" do
-      let(:provider) { build_stubbed(:provider, :archived) }
+      let(:provider) { build_stubbed(:provider, :archived, onboarded_at: onboarded_at, first_active_at: onboarded_at) }
 
       it "renders the archived tag in the title" do
         result = helper.provider_summary_cards([provider]).first
@@ -56,7 +58,7 @@ RSpec.describe ProviderHelper, type: :helper do
     end
 
     context "when debug mode is enabled" do
-      let(:provider) { build_stubbed(:provider) }
+      let(:provider) { build_stubbed(:provider, onboarded_at: onboarded_at, first_active_at: onboarded_at) }
       let(:providers) { [provider] }
 
       before do
@@ -172,7 +174,7 @@ RSpec.describe ProviderHelper, type: :helper do
   end
 
   describe "#provider_details_rows" do
-    let(:provider) { create(:provider, operating_name: "Test", legal_name: nil, urn: nil) }
+    let(:provider) { create(:provider, operating_name: "Test", legal_name: nil, urn: nil, onboarded_at: onboarded_at, first_active_at: onboarded_at) }
 
     it "returns the expected rows with 'Not entered' where applicable" do
       expect(helper.provider_details_rows(provider)).to eq([
@@ -209,11 +211,11 @@ RSpec.describe ProviderHelper, type: :helper do
           value: { text: provider.code },
           actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
         },
-        { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
-        { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
+        { key: { text: "Onboard at" }, value: { text: onboarded_at.to_date.to_fs(:govuk) } },
+        { key: { text: "First active at" }, value: { text: onboarded_at.to_date.to_fs(:govuk) } },
         {
           key: { text: "Active academic years" },
-          value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" },
+          value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year} to #{current_academic_year + 1} - current</li></ul>" },
         },
         {
           key: { text: "Inactive periods" },
@@ -223,7 +225,7 @@ RSpec.describe ProviderHelper, type: :helper do
     end
 
     context "when all values are present" do
-      let(:provider) { create(:provider, :scitt) }
+      let(:provider) { create(:provider, :scitt, onboarded_at: onboarded_at, first_active_at: onboarded_at) }
 
       it "returns the expected rows without 'Not entered'" do
         expect(helper.provider_details_rows(provider)).to eq([
@@ -260,11 +262,11 @@ RSpec.describe ProviderHelper, type: :helper do
             value: { text: provider.code },
             actions: [{ href: edit_provider_path(provider), visually_hidden_text: "provider code" }],
           },
-          { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
-          { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
+          { key: { text: "Onboard at" }, value: { text: onboarded_at.to_date.to_fs(:govuk) } },
+          { key: { text: "First active at" }, value: { text: onboarded_at.to_date.to_fs(:govuk) } },
           {
             key: { text: "Active academic years" },
-            value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" },
+            value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year} to #{current_academic_year + 1} - current</li></ul>" },
           },
           {
             key: { text: "Inactive periods" },
@@ -275,8 +277,7 @@ RSpec.describe ProviderHelper, type: :helper do
     end
 
     context "when the provider has inactive periods" do
-      let(:onboard_date) { 3.years.ago }
-      let(:provider) { create(:provider, :scitt, :with_inactive_period, onboarded_at: onboard_date, first_active_at: onboard_date) }
+      let(:provider) { create(:provider, :scitt, :with_inactive_period, onboarded_at: onboarded_at, first_active_at: onboarded_at) }
 
       it "returns the expected rows without 'Not entered'" do
         expect(helper.provider_details_rows(provider)).to eq([
@@ -315,19 +316,19 @@ RSpec.describe ProviderHelper, type: :helper do
           },
           {
             key: { text: "Onboard at" },
-            value: { text: onboard_date.to_date.to_fs(:govuk) }
+            value: { text: onboarded_at.to_date.to_fs(:govuk) }
           },
           {
             key: { text: "First active at" },
-            value: { text: onboard_date.to_date.to_fs(:govuk) }
+            value: { text: onboarded_at.to_date.to_fs(:govuk) }
           },
           {
             key: { text: "Active academic years" },
-            value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" },
+            value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year} to #{current_academic_year + 1} - current</li></ul>" },
           },
           {
             key: { text: "Inactive periods" },
-            value: { text: "<ul class=\"govuk-list govuk-list\"><li><dl class=\"govuk-summary-list\"><div class=\"govuk-summary-list__row\"><dt class=\"govuk-summary-list__key\">Starts on</dt><dd class=\"govuk-summary-list__value\">1 August 2024</dd></div><div class=\"govuk-summary-list__row\"><dt class=\"govuk-summary-list__key\">Ends on</dt><dd class=\"govuk-summary-list__value\">1 August 2025</dd></div></dl></li></ul>" }
+            value: { text: "<ul class=\"govuk-list govuk-list\"><li><dl class=\"govuk-summary-list\"><div class=\"govuk-summary-list__row\"><dt class=\"govuk-summary-list__key\">Starts on</dt><dd class=\"govuk-summary-list__value\">1 August #{current_academic_year - 1}</dd></div><div class=\"govuk-summary-list__row\"><dt class=\"govuk-summary-list__key\">Ends on</dt><dd class=\"govuk-summary-list__value\">31 July #{current_academic_year}</dd></div></dl></li></ul>" }
           },
         ])
       end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ProviderHelper, type: :helper do
+  let(:current_academic_year) { AcademicYearCalculator.current_academic_year }
   describe "#provider_summary_cards" do
     let(:provider) { create(:provider, legal_name: nil, operating_name: "School of learning", urn: "50000") }
     let(:providers) { [provider] }
@@ -26,7 +27,7 @@ RSpec.describe ProviderHelper, type: :helper do
         { key: { text: "Accreditation status" }, value: { text: provider.accreditation_status_label } },
         { key: { text: "Operating name" }, value: { text: provider.operating_name } },
         { key: { text: "Legal name" }, value: { text: "Not entered", classes: "govuk-hint" } },
-        { key: { text: "Academic years" }, value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' } },
+        { key: { text: "Active academic years" }, value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" } },
       ])
     end
 
@@ -211,9 +212,8 @@ RSpec.describe ProviderHelper, type: :helper do
         { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
         { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
         {
-          key: { text: "Academic years" },
-          value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
-          actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
+          key: { text: "Active academic years" },
+          value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" },
         },
         {
           key: { text: "Inactive periods" },
@@ -263,9 +263,8 @@ RSpec.describe ProviderHelper, type: :helper do
           { key: { text: "Onboard at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
           { key: { text: "First active at" }, value: { text: Time.zone.today.to_fs(:govuk) } },
           {
-            key: { text: "Academic years" },
-            value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
-            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
+            key: { text: "Active academic years" },
+            value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" },
           },
           {
             key: { text: "Inactive periods" },
@@ -323,9 +322,8 @@ RSpec.describe ProviderHelper, type: :helper do
             value: { text: onboard_date.to_date.to_fs(:govuk) }
           },
           {
-            key: { text: "Academic years" },
-            value: { text: '<ul class="govuk-list govuk-list--bullet"><li>2025 to 2026 - current</li></ul>' },
-            actions: [{ href: edit_provider_path(provider), visually_hidden_text: "academic years" }],
+            key: { text: "Active academic years" },
+            value: { text: "<ul class=\"govuk-list govuk-list--bullet\"><li>#{current_academic_year + 1} to #{current_academic_year + 2} - next</li></ul>" },
           },
           {
             key: { text: "Inactive periods" },

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -355,10 +355,10 @@ RSpec.describe Provider, type: :model do
   end
 
   describe ".active_academic_years" do
-    let(:provider) { create(:provider, :with_inactive_period) }
+    let(:provider) { create(:provider, :with_inactive_period, first_active_at: 2.years.ago) }
 
     it "returns all active academic years for the provider" do
-      active_academic_years = AcademicYear.where("lower(duration) > ?", provider.inactive_periods.first["end_date"])
+      active_academic_years = AcademicYear.where("lower(duration) > ? AND lower(duration) < ?", provider.inactive_periods.first["end_date"], Time.zone.today)
       expect(provider.active_academic_years.pluck(:id)).to match(active_academic_years.pluck(:id))
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -353,4 +353,13 @@ RSpec.describe Provider, type: :model do
       end
     end
   end
+
+  describe ".active_academic_years" do
+    let(:provider) { create(:provider, :with_inactive_period) }
+
+    it "returns all active academic years for the provider" do
+      active_academic_years = AcademicYear.where("lower(duration) > ?", provider.inactive_periods.first["end_date"])
+      expect(provider.active_academic_years.pluck(:id)).to match(active_academic_years.pluck(:id))
+    end
+  end
 end

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -151,7 +151,7 @@ FactoryBot.define do
           previous_academic_year = create(:academic_year, :previous)
 
           provider.inactive_periods << { start_date: previous_academic_year.duration.begin,
-                                         end_date: previous_academic_year.duration.end,
+                                         end_date: previous_academic_year.duration.end - 1.day,
                                          reason_for_inactive: "None given" }
           provider.save!
         end


### PR DESCRIPTION
### Context

https://trello.com/c/oEQo1tPu/481-display-the-active-academic-year-on-the-summary-list-and-summary-card

### Changes proposed in this pull request

Calculate active academic years from inactive periods and onboarding date, then display them

<img width="3348" height="3436" alt="Screenshot 2026-06-26 at 16-16-49 2Schools Consortium - Provider - Register of training providers - GOV UK" src="https://github.com/user-attachments/assets/22402b72-b3af-48af-b437-589d0080eb63" />



### Guidance to review
