### PR TITLE
[0557] Fixed an issue where by api user can navigate to url unchecked

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  rescue_from Pundit::NotAuthorizedError do
+    render "errors/forbidden", status: :forbidden, formats: [:html]
+  end
+
 private
 
   # dfe and otp objects can both be instantiated as `.begin_session!` will always create

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -16,6 +16,8 @@ class ProvidersController < ApplicationController
     @pagy, @records = pagy(provider_query.order_by_operating_name, limit: 10)
 
     @academic_years = AcademicYear.next_and_older
+
+    authorize provider_query
   end
 
   def show

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -1,31 +1,27 @@
 class ProviderPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if user.api_user?
-        scope.none
-      else
-        scope.kept
-      end
+      scope.kept
     end
   end
 
   def index?
-    true
+    !user.api_user
   end
 
   def show?
-    record.kept?
+    record.kept? && !user.api_user
   end
 
   def edit?
-    record.kept? && record.not_archived?
+    record.kept? && record.not_archived?  && !user.api_user
   end
 
   def update?
-    record.kept? && record.not_archived?
+    record.kept? && record.not_archived?  && !user.api_user
   end
 
   def create?
-    record.new_record?
+    record.new_record? && !user.api_user
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,14 +14,14 @@ class UserPolicy < ApplicationPolicy
   end
 
   def edit?
-    record.kept? && user != record
+    record.kept? && user != record && !user.api_user
   end
 
   def update?
-    record.kept? && user != record
+    record.kept? && user != record && !user.api_user
   end
 
   def create?
-    record.new_record?
+    record.new_record? && !user.api_user
   end
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,6 @@
+<%= content_for :page_title, "You do not have permission to perform this action" %>
+
+<h1 class="govuk-heading-l">You do not have permission to perform this action</h1>
+<p class="govuk-body">
+  If you think you should have access, contact: <%= support_email %>.
+</p>

--- a/spec/features/end_to_end/forbidden_access_spec.rb
+++ b/spec/features/end_to_end/forbidden_access_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.feature "Forbidden access" do
+  scenario "for an api user accessing providers listing" do
+    given_i_am_on_the_start_page
+    and_i_am_not_signed_in
+    and_there_is_no_sign_out_link
+    and_i_am_registered_as_an_api_user
+    and_i_have_a_dfe_sign_in_account_and_am_an_api_user
+    and_i_sign_in_via_dfe_sign_in
+
+    and_i_am_redirected_to_api_clients_page
+    and_i_click_on("Your account")
+    and_i_go_to_the_account_page
+    and_i_click_on("Register of training providers")
+    and_i_am_taken_to("/api_clients")
+
+    when_i_visit("/providers")
+    then_i_am_taken_shown_the_forbidden_page
+    when_i_click_on("Sign out")
+    then_i_logout_via_sso
+    and_i_am_taken_to("/")
+    and_i_am_not_signed_in
+  end
+
+  def given_i_am_on_the_start_page
+    visit "/"
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    and_i_visit_the_sign_in_page
+  end
+
+  def and_i_go_to_the_users_page
+    expect(page).to have_current_path("/users")
+  end
+
+  def and_i_go_to_the_account_page
+    expect(page).to have_current_path("/account")
+  end
+
+  def then_i_logout_via_sso
+    # NOTE: 1, signs out via external sso
+    expect(current_url).to start_with("https://test-oidc.signin.education.gov.uk/session/end")
+    uri = URI.parse(current_url)
+    query = CGI.parse(uri.query)
+    expect(uri.path).to eq("/session/end")
+
+    # NOTE: 2, used the configured signout link
+    sign_out_link = "http://www.example.com/auth/dfe/sign-out"
+    expect(query["post_logout_redirect_uri"].first).to eq(sign_out_link)
+
+    # NOTE: 3, hand-off visit our sign out link afterwards
+    visit sign_out_link
+  end
+
+  def and_i_am_not_signed_in
+    expect(page).to have_link("Sign in")
+    and_there_is_no_sign_out_link
+  end
+
+  def and_i_am_redirected_to_api_clients_page
+    expect(page).to have_current_path("/api_clients")
+  end
+
+  def and_there_is_no_sign_out_link
+    expect(page).not_to have_link("Sign out")
+  end
+
+  def when_i_visit(path)
+    visit path
+  end
+
+  def then_i_am_taken_shown_the_forbidden_page
+    expect(page).to have_current_path("/providers")
+    expect(page.status_code).to eq(403)
+    expect(page).to have_content("You do not have permission to perform this action")
+    expect(page).to have_title("You do not have permission to perform this action")
+  end
+end


### PR DESCRIPTION
### Context
API user

### Changes proposed in this pull request
Enforce API user to go thro policy

### Guidance to review

An API user should not be able to view anything other the the list of their own api clients.

1. Login as an API user
2. Navigate to https://register-training-providers-pr-538.test.teacherservices.cloud/providers
    a. Or any other that do not have access (visit as normal user and copy down the url)
4. See the the Forbidden message

<img width="1016" height="675" alt="image" src="https://github.com/user-attachments/assets/1a1e41d6-542f-4da8-a976-6068d692ec73" />

