### PR TITLE
[0553] Fixed an issue whereby another person can view someone else confirmation

### DIFF
--- a/app/controllers/api_clients/confirmations_controller.rb
+++ b/app/controllers/api_clients/confirmations_controller.rb
@@ -3,7 +3,8 @@ module ApiClients
     before_action :redirect_if_current_active_token
 
     def show
-      authorize api_client
+      authorize api_client, :confirm?
+
       @token = Api::Clients::CreateToken.call(client_name: api_client.name, created_by_email: current_user.email,
                                               expires_at: api_client_form.expires_at.to_s).token
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  rescue_from Pundit::NotAuthorizedError do
+    render "errors/forbidden", status: :forbidden, formats: [:html]
+  end
+
 private
 
   # dfe and otp objects can both be instantiated as `.begin_session!` will always create

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -16,6 +16,8 @@ class ProvidersController < ApplicationController
     @pagy, @records = pagy(provider_query.order_by_operating_name, limit: 10)
 
     @academic_years = AcademicYear.next_and_older
+
+    authorize provider_query
   end
 
   def show

--- a/app/policies/api_client_policy.rb
+++ b/app/policies/api_client_policy.rb
@@ -9,6 +9,10 @@ class ApiClientPolicy < ApplicationPolicy
     end
   end
 
+  def confirm?
+    record.kept? && record.created_by == user
+  end
+
   def show?
     record.kept?
   end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -1,31 +1,27 @@
 class ProviderPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if user.api_user?
-        scope.none
-      else
-        scope.kept
-      end
+      scope.kept
     end
   end
 
   def index?
-    true
+    !user.api_user
   end
 
   def show?
-    record.kept?
+    record.kept? && !user.api_user
   end
 
   def edit?
-    record.kept? && record.not_archived?
+    record.kept? && record.not_archived?  && !user.api_user
   end
 
   def update?
-    record.kept? && record.not_archived?
+    record.kept? && record.not_archived?  && !user.api_user
   end
 
   def create?
-    record.new_record?
+    record.new_record? && !user.api_user
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,14 +14,14 @@ class UserPolicy < ApplicationPolicy
   end
 
   def edit?
-    record.kept? && user != record
+    record.kept? && user != record && !user.api_user
   end
 
   def update?
-    record.kept? && user != record
+    record.kept? && user != record && !user.api_user
   end
 
   def create?
-    record.new_record?
+    record.new_record? && !user.api_user
   end
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,6 @@
+<%= content_for :page_title, "You do not have permission to perform this action" %>
+
+<h1 class="govuk-heading-l">You do not have permission to perform this action</h1>
+<p class="govuk-body">
+  If you think you should have access, contact: <%= support_email %>.
+</p>

--- a/spec/features/end_to_end/api_clients/creating_api_client_spec.rb
+++ b/spec/features/end_to_end/api_clients/creating_api_client_spec.rb
@@ -29,6 +29,13 @@ RSpec.feature "api_client management" do
     and_i_am_redirected_to_the_index_page_when_trying_to_revisit_the_confirmation_page
   end
 
+  scenario "viewing someone else's api_client confirmation" do
+    given_i_am_an_authenticated_user
+    and_there_is_a_new_api_client_created_by_someone_else
+    when_i_visit("/api_clients/#{someone_else_api_client.id}/confirmation")
+    then_i_am_taken_shown_the_forbidden_page
+  end
+
   def and_i_can_see_the_page_title_api_clients_without_the_count
     expect(page).to have_title("API clients - Register of training providers - GOV.UK")
   end
@@ -43,6 +50,14 @@ RSpec.feature "api_client management" do
 
   def api_client
     @api_client ||= build(:api_client)
+  end
+
+  def and_there_is_a_new_api_client_created_by_someone_else
+    api_client.save
+  end
+
+  def someone_else_api_client
+    api_client
   end
 
   def saved_api_client
@@ -92,5 +107,16 @@ RSpec.feature "api_client management" do
 
   def start_year
     Date.current.year + 1
+  end
+
+  def then_i_am_taken_shown_the_forbidden_page
+    expect(page).to have_current_path("/api_clients/#{someone_else_api_client.id}/confirmation")
+    expect(page.status_code).to eq(403)
+    expect(page).to have_content("You do not have permission to perform this action")
+    expect(page).to have_title("You do not have permission to perform this action")
+  end
+
+  def when_i_visit(path)
+    visit path
   end
 end

--- a/spec/features/end_to_end/forbidden_access_spec.rb
+++ b/spec/features/end_to_end/forbidden_access_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.feature "Forbidden access" do
+  scenario "for an api user accessing providers listing" do
+    given_i_am_on_the_start_page
+    and_i_am_not_signed_in
+    and_there_is_no_sign_out_link
+    and_i_am_registered_as_an_api_user
+    and_i_have_a_dfe_sign_in_account_and_am_an_api_user
+    and_i_sign_in_via_dfe_sign_in
+
+    and_i_am_redirected_to_api_clients_page
+    and_i_click_on("Your account")
+    and_i_go_to_the_account_page
+    and_i_click_on("Register of training providers")
+    and_i_am_taken_to("/api_clients")
+
+    when_i_visit("/providers")
+    then_i_am_taken_shown_the_forbidden_page
+    when_i_click_on("Sign out")
+    then_i_logout_via_sso
+    and_i_am_taken_to("/")
+    and_i_am_not_signed_in
+  end
+
+  def given_i_am_on_the_start_page
+    visit "/"
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    and_i_visit_the_sign_in_page
+  end
+
+  def and_i_go_to_the_users_page
+    expect(page).to have_current_path("/users")
+  end
+
+  def and_i_go_to_the_account_page
+    expect(page).to have_current_path("/account")
+  end
+
+  def then_i_logout_via_sso
+    # NOTE: 1, signs out via external sso
+    expect(current_url).to start_with("https://test-oidc.signin.education.gov.uk/session/end")
+    uri = URI.parse(current_url)
+    query = CGI.parse(uri.query)
+    expect(uri.path).to eq("/session/end")
+
+    # NOTE: 2, used the configured signout link
+    sign_out_link = "http://www.example.com/auth/dfe/sign-out"
+    expect(query["post_logout_redirect_uri"].first).to eq(sign_out_link)
+
+    # NOTE: 3, hand-off visit our sign out link afterwards
+    visit sign_out_link
+  end
+
+  def and_i_am_not_signed_in
+    expect(page).to have_link("Sign in")
+    and_there_is_no_sign_out_link
+  end
+
+  def and_i_am_redirected_to_api_clients_page
+    expect(page).to have_current_path("/api_clients")
+  end
+
+  def and_there_is_no_sign_out_link
+    expect(page).not_to have_link("Sign out")
+  end
+
+  def when_i_visit(path)
+    visit path
+  end
+
+  def then_i_am_taken_shown_the_forbidden_page
+    expect(page).to have_current_path("/providers")
+    expect(page.status_code).to eq(403)
+    expect(page).to have_content("You do not have permission to perform this action")
+    expect(page).to have_title("You do not have permission to perform this action")
+  end
+end

--- a/spec/policies/api_client_policy_spec.rb
+++ b/spec/policies/api_client_policy_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe ApiClientPolicy do
     end
   end
 
+  permissions :confirm? do
+    it "permits access if the api_client is kept and created by the user" do
+      expect(subject).to permit(api_user, api_user_client)
+    end
+
+    it "denies access if the api_client is kept but created by another user" do
+      expect(subject).not_to permit(api_user, api_client)
+    end
+
+    it "denies access if the api_client is discarded" do
+      expect(subject).not_to permit(api_user, discarded_api_client)
+    end
+  end
+
   describe ".policy_scope" do
     context "for an api user" do
       it "returns kept api clients created by the user" do


### PR DESCRIPTION
### Context
Another person can view someone else confirmation

### Changes proposed in this pull request
Fixed an issue whereby another person can view someone else confirmation

### Guidance to review

You need to create api client and share the confirmation url to another user and attempt to view it, before the creator has viewed it.

If did you will see the code or the forbidden page.


The content should only ever be displayed once and to the creator.