### PR TITLE
[0544] Session fixation session id not rotated after OIDC authentication completes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,6 +22,8 @@ class SessionsController < ApplicationController
   end
 
   def signout
+    reset_session
+
     redirect_to(root_path)
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,10 @@ class SessionsController < ApplicationController
   skip_before_action :check_user_is_active
 
   def callback
+    requested_path = session[:requested_path]
     reset_session
+
+    session[:requested_path] = requested_path if requested_path.present?
 
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,8 @@ class SessionsController < ApplicationController
   skip_before_action :check_user_is_active
 
   def callback
+    reset_session
+
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
 
     if current_user

--- a/spec/requests/dfe_signin_callback_spec.rb
+++ b/spec/requests/dfe_signin_callback_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "DfE Signin callback", type: :request do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user:)
+  end
+
+  after do
+    OmniAuth.config.mock_auth.clear
+  end
+
+  describe "GET /auth/dfe/callback" do
+    it "rotates the session cookie when signing in to prevent session fixation" do
+      get root_path
+
+      original_session_cookie = response.cookies["_register_of_training_providers_session"]
+
+      get "/auth/dfe/callback"
+
+      authenticated_session_cookie = response.cookies["_register_of_training_providers_session"]
+
+      expect(authenticated_session_cookie).not_to eq(original_session_cookie)
+      expect(session["dfe_sign_in_user"]).to be_present
+    end
+  end
+end

--- a/spec/requests/dfe_signin_callback_spec.rb
+++ b/spec/requests/dfe_signin_callback_spec.rb
@@ -26,5 +26,17 @@ RSpec.describe "DfE Signin callback", type: :request do
       expect(authenticated_session_cookie).not_to eq(original_session_cookie)
       expect(session["dfe_sign_in_user"]).to be_present
     end
+
+    it "preserves the requested path when resetting the session during login" do
+      requested_path = "/providers/requested_path"
+
+      get requested_path
+
+      expect(session[:requested_path]).to eq(requested_path)
+
+      get "/auth/dfe/callback"
+
+      expect(response).to redirect_to(requested_path)
+    end
   end
 end

--- a/spec/requests/dfe_signout_spec.rb
+++ b/spec/requests/dfe_signout_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "DfE Sign out", type: :request do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user:)
+  end
+
+  after do
+    OmniAuth.config.mock_auth.clear
+  end
+
+  describe "GET /auth/dfe/sign-out" do
+    it "clears the session when signing out" do
+      get "/auth/dfe/callback"
+
+      expect(session["dfe_sign_in_user"]).to be_present
+
+      old_session_cookie = response.cookies["_register_of_training_providers_session"]
+
+      get "/auth/dfe/sign-out"
+
+      new_session_cookie = response.cookies["_register_of_training_providers_session"]
+
+      expect(new_session_cookie).not_to eq(old_session_cookie)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Session fixation

### Changes proposed in this pull request
Fixed fixation issue
Fixed requested path issue
Fixed unclean sign out issue

### Guidance to review
The stress free way is to remove the changes in sessions controller and see the tests fails and watch it pass after it has been added back in.