### PR TITLE
[0543] Removed the ability to unknowingly overwriting dfe_sign_in_uid

### DIFF
--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -79,10 +79,16 @@ private
   def user_by_email
     return if email.blank?
 
-    User.kept.find_by(
+    user = User.kept.find_by(
       "LOWER(email) = ?",
       email&.downcase,
     )
+
+    return unless user
+
+    if user.dfe_sign_in_uid.blank?
+      user
+    end
   end
 
   def signed_in_from_dfe?

--- a/app/services/dfe_sign_in_users/update.rb
+++ b/app/services/dfe_sign_in_users/update.rb
@@ -12,8 +12,9 @@ module DfESignInUsers
       attributes = {
         last_signed_in_at: Time.zone.now,
         email: sign_in_user.email,
-        dfe_sign_in_uid: sign_in_user.dfe_sign_in_uid,
       }
+
+      attributes[:dfe_sign_in_uid] = sign_in_user.dfe_sign_in_uid if user.dfe_sign_in_uid.blank?
 
       attributes[:first_name] = sign_in_user.first_name if sign_in_user.first_name.present?
       attributes[:last_name] = sign_in_user.last_name if sign_in_user.last_name.present?

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -5,40 +5,47 @@ describe DfESignInUser do
     it "returns the DfE User when the user has signed in and has been recently active" do
       session = { "dfe_sign_in_user" => { "last_active_at" => Time.zone.now } }
 
-      signin_user = DfESignInUser.load_from_session(session)
-      expect(signin_user).not_to be_nil
+      sign_in_user = described_class.load_from_session(session)
+
+      expect(sign_in_user).not_to be_nil
     end
 
     it "returns nil when the user has signed in and has not been recently active" do
       session = { "dfe_sign_in_user" => { "last_active_at" => 1.day.ago } }
 
-      signin_user = DfESignInUser.load_from_session(session)
+      sign_in_user = described_class.load_from_session(session)
 
-      expect(signin_user).to be_nil
+      expect(sign_in_user).to be_nil
     end
 
     it "returns nil when the user has not signed in" do
       session = { "dfe_sign_in_user" => nil }
 
-      signin_user = DfESignInUser.load_from_session(session)
+      sign_in_user = described_class.load_from_session(session)
 
-      expect(signin_user).to be_nil
+      expect(sign_in_user).to be_nil
     end
 
     it "returns nil when the user does not have a last active timestamp" do
       session = { "dfe_sign_in_user" => { "last_active_at" => nil } }
 
-      signin_user = DfESignInUser.load_from_session(session)
+      sign_in_user = described_class.load_from_session(session)
 
-      expect(signin_user).to be_nil
+      expect(sign_in_user).to be_nil
     end
   end
 
   describe ".end_session!" do
-    it "delete the dfe_sign_in_user from session" do
-      session = { "dfe_sign_in_user" => nil }
+    it "deletes the dfe sign in user from session" do
+      session = {
+        "dfe_sign_in_user" => {
+          "email" => "example@example.com",
+        },
+      }
 
-      DfESignInUser.end_session!(session)
+      described_class.end_session!(session)
+
+      expect(session["dfe_sign_in_user"]).to be_nil
       expect(session).to be_empty
     end
   end
@@ -63,6 +70,61 @@ describe DfESignInUser do
         "https://test-oidc.signin.education.gov.uk/session/end?id_token_hint=" \
         "123&post_logout_redirect_uri=dfe_url%2Fauth%2Fdfe%2Fsign-out",
       )
+    end
+  end
+
+  describe "#user" do
+    context "when the user has a matching dfe sign in uid" do
+      it "finds the user by dfe sign in uid" do
+        user = create(:user, dfe_sign_in_uid: "dfe-123")
+
+        sign_in_user = described_class.new(
+          email: user.email,
+          dfe_sign_in_uid: "dfe-123",
+          first_name: "Test",
+          last_name: "User",
+        )
+
+        expect(sign_in_user.user).to eq(user)
+      end
+    end
+
+    context "when the user has no dfe sign in uid" do
+      it "finds the user by email to allow first time linking" do
+        user = create(
+          :user,
+          email: "test@education.gov.uk",
+          dfe_sign_in_uid: nil,
+        )
+
+        sign_in_user = described_class.new(
+          email: user.email,
+          dfe_sign_in_uid: "dfe-123",
+          first_name: "Test",
+          last_name: "User",
+        )
+
+        expect(sign_in_user.user).to eq(user)
+      end
+    end
+
+    context "when the email matches but the user is already linked to another dfe account" do
+      it "logs a warning and does not return the user by email fallback" do
+        create(
+          :user,
+          email: "test@education.gov.uk",
+          dfe_sign_in_uid: "existing-dfe-123",
+        )
+
+        sign_in_user = described_class.new(
+          email: "test@education.gov.uk",
+          dfe_sign_in_uid: "different-dfe-456",
+          first_name: "Test",
+          last_name: "User",
+        )
+
+        expect(sign_in_user.user).to be_nil
+      end
     end
   end
 end

--- a/spec/services/dfe_sign_in_users/update_spec.rb
+++ b/spec/services/dfe_sign_in_users/update_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe DfESignInUsers::Update do
+  describe "#call" do
+    it "sets the dfe sign in uid on first link" do
+      user = create(:user, dfe_sign_in_uid: nil)
+
+      sign_in_user = DfESignInUser.new(
+        email: user.email,
+        dfe_sign_in_uid: "dfe-123",
+        first_name: "Test",
+        last_name: "User",
+      )
+
+      described_class.call(
+        user:,
+        sign_in_user:,
+      )
+
+      expect(user.reload.dfe_sign_in_uid).to eq("dfe-123")
+    end
+
+    it "does not replace an existing dfe sign in uid" do
+      user = create(:user, dfe_sign_in_uid: "existing-dfe-123")
+
+      sign_in_user = DfESignInUser.new(
+        email: user.email,
+        dfe_sign_in_uid: "different-dfe-456",
+        first_name: "Test",
+        last_name: "User",
+      )
+
+      described_class.call(
+        user:,
+        sign_in_user:,
+      )
+
+      expect(user.reload.dfe_sign_in_uid).to eq("existing-dfe-123")
+    end
+  end
+end


### PR DESCRIPTION
### Context

The ability to unknowingly overwriting `dfe_sign_in_uid`

### Changes proposed in this pull request

Removed the ability to unknowingly overwriting `dfe_sign_in_uid`

### Guidance to review
This is to reinforce that fact the once a `dfe_sign_in_uid` is captured as the linking from `email` and `dfe_sign_in_uid` has priority thereafter and cannot be overwritten.

If a user has a `dfe_sign_in_uid` and an `email`



The `dfe_sign_in_uid` will be used for lookup firstly than the `email`



If the `email` has a different `dfe_sign_in_uid` than do not let them in.