### PR TITLE
2829 - Additional makefile functions for Postgres Upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,3 +174,52 @@ action-group: set-azure-account # make production action-group ACTION_GROUP_EMAI
 	$(if $(ACTION_GROUP_EMAIL), , $(error Please specify a notification email for the action group))
 	az group create -l uksouth -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --tags "Product=${SERVICE_NAME}"
 	az monitor action-group create -n ${AZURE_RESOURCE_PREFIX}-${SERVICE_NAME} -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --action email ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-email ${ACTION_GROUP_EMAIL}
+
+set-pgserver:
+	$(eval SERVERNAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg)
+
+list-pglogs: composed-variables set-pgserver set-azure-account
+	az postgres flexible-server server-logs list --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME}
+
+download-pglogs: composed-variables set-pgserver set-azure-account
+	$(if $(LOG_NAME), , $(error Please specify a LOG_NAME for download))
+	az postgres flexible-server server-logs download --name ${LOG_NAME} --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME}
+	ls -l $(LOG_NAME)*
+
+enable-pglogs: composed-variables set-pgserver set-azure-account
+	echo "Enabling server logs for PostgreSQL server ${SERVERNAME}"
+	echo "Current Value"
+	az postgres flexible-server parameter show --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME} --name logfiles.download_enable --query value
+	echo "Setting Value"
+	az postgres flexible-server parameter set --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME} --name logfiles.download_enable --value on
+	echo "New Value"
+	az postgres flexible-server parameter show --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME} --name logfiles.download_enable --query value
+
+disable-pglogs: composed-variables set-pgserver set-azure-account
+	echo "Current Value"
+	az postgres flexible-server parameter show --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME} --name logfiles.download_enable --query value
+	echo "Setting Value"
+	az postgres flexible-server parameter set --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME} --name logfiles.download_enable --value off
+	echo "New Value"
+	az postgres flexible-server parameter show --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME} --name logfiles.download_enable --query value
+
+show-service: get-cluster-credentials
+	$(if $(PR_NUMBER), $(eval export DSUFFIX="-pr-${PR_NUMBER}"), $(eval export DSUFFIX="-${CONFIG}") )
+	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/application/config/$(CONFIG).tfvars.json))
+	echo "Show service deployments"
+	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}
+	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-worker
+
+scale-app: get-cluster-credentials
+	$(if $(PR_NUMBER), $(eval export DSUFFIX="-pr-${PR_NUMBER}"), $(eval export DSUFFIX="-${CONFIG}") )
+	$(if $(REPLICAS),,$(error Missing REPLICAS))
+	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/application/config/$(CONFIG).tfvars.json))
+	echo "Scaling app to ${REPLICAS}"
+	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX} --replicas ${REPLICAS}
+
+scale-worker: get-cluster-credentials
+	$(if $(PR_NUMBER), $(eval export DSUFFIX="-pr-${PR_NUMBER}"), $(eval export DSUFFIX="-${CONFIG}") )
+	$(if $(REPLICAS),,$(error Missing REPLICAS))
+	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/application/config/$(CONFIG).tfvars.json))
+	echo "Scaling worker to ${REPLICAS}"
+	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-worker --replicas ${REPLICAS}

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -1,8 +1,9 @@
 {
   "cluster": "test",
   "namespace": "bat-qa",
-  "deploy_azure_backing_services": false,
+  "deploy_azure_backing_services": true,
   "enable_postgres_ssl": false,
   "enable_dfe_analytics_federated_auth": true,
-  "gcp_table_deletion_protection": false
+  "gcp_table_deletion_protection": false,
+  "postgres_version": 17
 }


### PR DESCRIPTION
### Context

We need to upgrade Postgres DB to version 17.
https://trello.com/c/m6tlxrdZ/2829-upgrade-rotp-postgres-version

### Changes proposed in this pull request

Additional commands have been added to Makefile to allow the ability to enable and disable Postgres logs and to scale Kubernetes pods.
Review Postgres version changed to 17 and deploy_azure_backing_services changed to true to allow a review app to be deployed and tested.

### Guidance to review

Run command `make qa pg-logs` which should return an empty list.
Run command `make qa show-service`  which will return the app and worker Kubernetes deployments.

<img width="634" height="117" alt="image" src="https://github.com/user-attachments/assets/f0674b80-dbef-4e32-ae0d-715eba19628a" />

Deployed Review App
https://register-training-providers-pr-543.test.teacherservices.cloud//