### PR TITLE
[0549] Adding logging for handoff from DSi and denied authorization 

### DIFF
--- a/app/components/personas/view.html.erb
+++ b/app/components/personas/view.html.erb
@@ -4,6 +4,7 @@
   <%= hidden_field_tag "email", persona.email %>
   <%= hidden_field_tag "first_name", persona.first_name %>
   <%= hidden_field_tag "last_name", persona.last_name %>
+  <%= hidden_field_tag("uid", persona.dfe_sign_in_uid) if persona.dfe_sign_in_uid.present? %>
   <%= f.submit "Sign in as #{persona.name}", class: "govuk-button govuk-!-margin-bottom-8" %>
 <% end %>
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,16 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
-  rescue_from Pundit::NotAuthorizedError do
+  rescue_from Pundit::NotAuthorizedError do |exception|
+    Rails.logger.warn(
+      event: "authorization_denied",
+      user_id: current_user&.id,
+      controller: controller_name,
+      action: action_name,
+      path: request.path,
+      policy: exception.policy.class.name,
+      query: exception.query,
+    )
     render "errors/forbidden", status: :forbidden, formats: [:html]
   end
 

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -77,18 +77,27 @@ private
   end
 
   def user_by_email
-    return if email.blank?
+    return log_dfe_identity_failure("missing_email") if email.blank?
 
-    user = User.kept.find_by(
-      "LOWER(email) = ?",
-      email&.downcase,
+    user = User.find_by("LOWER(email) = ?", email.downcase)
+
+    return log_dfe_identity_failure("unknown_user") unless user
+    return log_dfe_identity_failure("discarded_user",
+                                    user_id: user.id) unless user.kept?
+    return log_dfe_identity_failure("mismatch",
+                                    user_id: user.id,
+                                    existing_dfe_sign_in_uid: user.dfe_sign_in_uid,) if user.dfe_sign_in_uid.present?
+
+    user
+  end
+
+  def log_dfe_identity_failure(event, extra = {})
+    Rails.logger.warn(
+      event: "dfe_sign_in_identity_#{event}",
+      message: "Refusing email fallback",
+      attempted_dfe_sign_in_uid: dfe_sign_in_uid, **extra,
     )
-
-    return unless user
-
-    if user.dfe_sign_in_uid.blank?
-      user
-    end
+    nil
   end
 
   def signed_in_from_dfe?

--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -43,6 +43,9 @@ PERSONAS = [
     api_user?: true },
 ].freeze
 
-NON_EXISTING_PERSONA = { first_name: "Tyler", last_name: "Durden", email: "test7@education.gov.uk" }.freeze
+NON_EXISTING_PERSONA = { first_name: "Tyler",
+                         last_name: "Durden",
+                         email: "test7@education.gov.uk",
+                         dfe_sign_in_uid: "Mr-Durden" }.freeze
 
 PERSONA_EMAILS = PERSONAS.pluck(:email)

--- a/lib/env.rb
+++ b/lib/env.rb
@@ -13,14 +13,14 @@ module Env
     if boolean_method?(method)
       return interpret_bool(val) unless val.nil?
 
-      logger.warn("[Env.#{method}] ENV['#{key}'] is missing")
+      logger.info("[Env.#{method}] ENV['#{key}'] is missing")
       return fallback.nil? ? false : fallback
     end
 
     if ENV.key?(key)
       val
     else
-      logger.warn("[Env.#{method}] ENV['#{key}'] is missing")
+      logger.info("[Env.#{method}] ENV['#{key}'] is missing")
       fallback
     end
   end

--- a/spec/features/end_to_end/forbidden_access_spec.rb
+++ b/spec/features/end_to_end/forbidden_access_spec.rb
@@ -15,6 +15,16 @@ RSpec.feature "Forbidden access" do
     and_i_click_on("Register of training providers")
     and_i_am_taken_to("/api_clients")
 
+    expect(Rails.logger).to receive(:warn).with(
+      event: "authorization_denied",
+      user_id: current_api_user.id,
+      controller: "providers",
+      action: "index",
+      path: "/providers",
+      policy: "ProviderPolicy",
+      query: "index?",
+    )
+
     when_i_visit("/providers")
     then_i_am_taken_shown_the_forbidden_page
     when_i_click_on("Sign out")

--- a/spec/lib/env_spec.rb
+++ b/spec/lib/env_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Env do
-  let(:logger) { instance_double(Logger, warn: nil) }
+  let(:logger) { instance_double(Logger, info: nil) }
 
   before do
     allow(Env).to receive(:logger).and_return(logger)
@@ -18,9 +18,9 @@ RSpec.describe Env do
       expect(Env.some_environment_variables("default-value")).to eq("env-value")
     end
 
-    it "does not log a warning" do
+    it "does not log a info" do
       Env.some_environment_variables("default-value")
-      expect(logger).not_to have_received(:warn)
+      expect(logger).not_to have_received(:info)
     end
   end
 
@@ -33,9 +33,9 @@ RSpec.describe Env do
       expect(Env.some_environment_variables("default-value")).to eq("default-value")
     end
 
-    it "logs a warning" do
+    it "logs a info" do
       Env.some_environment_variables("default-value")
-      expect(logger).to have_received(:warn).with(
+      expect(logger).to have_received(:info).with(
         "[Env.some_environment_variables] ENV['SOME_ENVIRONMENT_VARIABLES'] is missing"
       )
     end
@@ -77,9 +77,9 @@ RSpec.describe Env do
         expect(Env.some_feature?(true)).to be true
       end
 
-      it "logs a warning" do
+      it "logs a info" do
         Env.some_feature?
-        expect(logger).to have_received(:warn).with("[Env.some_feature?] ENV['SOME_FEATURE'] is missing")
+        expect(logger).to have_received(:info).with("[Env.some_feature?] ENV['SOME_FEATURE'] is missing")
       end
     end
   end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -74,15 +74,15 @@ describe DfESignInUser do
   end
 
   describe "#user" do
-    context "when the user has a matching dfe sign in uid" do
-      it "finds the user by dfe sign in uid" do
+    context "when the dfe sign in uid matches" do
+      it "returns the user by dfe sign in uid" do
         user = create(:user, dfe_sign_in_uid: "dfe-123")
 
         sign_in_user = described_class.new(
           email: user.email,
           dfe_sign_in_uid: "dfe-123",
-          first_name: "Test",
-          last_name: "User",
+          first_name: user.first_name,
+          last_name: user.last_name,
         )
 
         expect(sign_in_user.user).to eq(user)
@@ -90,7 +90,7 @@ describe DfESignInUser do
     end
 
     context "when the user has no dfe sign in uid" do
-      it "finds the user by email to allow first time linking" do
+      it "returns the user by email for first time linking" do
         user = create(
           :user,
           email: "test@education.gov.uk",
@@ -100,27 +100,100 @@ describe DfESignInUser do
         sign_in_user = described_class.new(
           email: user.email,
           dfe_sign_in_uid: "dfe-123",
-          first_name: "Test",
-          last_name: "User",
+          first_name: user.first_name,
+          last_name: user.last_name,
         )
 
         expect(sign_in_user.user).to eq(user)
       end
     end
 
+    context "when the email is missing" do
+      it "logs a warning and does not fallback by email" do
+        sign_in_user = described_class.new(
+          email: nil,
+          dfe_sign_in_uid: "dfe-123",
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name
+        )
+
+        expect(Rails.logger).to receive(:warn).with(
+          event: "dfe_sign_in_identity_missing_email",
+          message: "Refusing email fallback",
+          attempted_dfe_sign_in_uid: "dfe-123",
+        )
+
+        expect(sign_in_user.user).to be_nil
+      end
+    end
+
+    context "when no user exists for the email" do
+      it "logs a warning and does not return a user" do
+        sign_in_user = described_class.new(
+          email: "missing@education.gov.uk",
+          dfe_sign_in_uid: "dfe-123",
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name
+        )
+
+        expect(Rails.logger).to receive(:warn).with(
+          event: "dfe_sign_in_identity_unknown_user",
+          message: "Refusing email fallback",
+          attempted_dfe_sign_in_uid: "dfe-123",
+        )
+
+        expect(sign_in_user.user).to be_nil
+      end
+    end
+
+    context "when the email matches a discarded user" do
+      it "logs a warning and does not return the user" do
+        user = create(
+          :user,
+          :discarded,
+          email: "test@education.gov.uk",
+          dfe_sign_in_uid: nil,
+        )
+
+        sign_in_user = described_class.new(
+          email: user.email,
+          dfe_sign_in_uid: "dfe-123",
+          first_name: user.first_name,
+          last_name: user.last_name
+        )
+
+        expect(Rails.logger).to receive(:warn).with(
+          event: "dfe_sign_in_identity_discarded_user",
+          message: "Refusing email fallback",
+          attempted_dfe_sign_in_uid: "dfe-123",
+          user_id: user.id,
+        )
+
+        expect(sign_in_user.user).to be_nil
+      end
+    end
+
     context "when the email matches but the user is already linked to another dfe account" do
       it "logs a warning and does not return the user by email fallback" do
-        create(
+        user = create(
           :user,
           email: "test@education.gov.uk",
           dfe_sign_in_uid: "existing-dfe-123",
         )
 
         sign_in_user = described_class.new(
-          email: "test@education.gov.uk",
+          email: user.email,
           dfe_sign_in_uid: "different-dfe-456",
-          first_name: "Test",
-          last_name: "User",
+          first_name: user.first_name,
+          last_name: user.last_name
+        )
+
+        expect(Rails.logger).to receive(:warn).with(
+          event: "dfe_sign_in_identity_mismatch",
+          message: "Refusing email fallback",
+          user_id: user.id,
+          attempted_dfe_sign_in_uid: "different-dfe-456",
+          existing_dfe_sign_in_uid: "existing-dfe-123",
         )
 
         expect(sign_in_user.user).to be_nil


### PR DESCRIPTION
### Context
Logging

### Changes proposed in this pull request

Added logging for handoff from DSi
Added logging for handoff from DSi and denied authorization 

### Guidance to review

Logs the fact that 

- an unknown user to RoTP has attempted to login (Known in DSI but not whitelisted in RoTP)
- a discarded user in RoTP has attempted to login
- a mismatch user has attempted to login (related to the first PR)
- an authenticated user has attempted an action on item without authorization (view resources such as providers)

