### PR TITLE
[0547] Throttle and logging of deleting users

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -186,12 +186,13 @@ jobs:
       - name: Run test suite
         run: bundle exec rspec
 
-      - name: Upload test failure screenshots
+      - name: Upload test failure artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: test-failure-screenshots
-          path: tmp/screenshots/
+          path: |
+            tmp/screenshots/
+            tmp/db_dumps/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,18 @@ class ApplicationController < ActionController::Base
     render "errors/forbidden", status: :forbidden, formats: [:html]
   end
 
+  rescue_from ActionController::TooManyRequests do |_exception|
+    Rails.logger.warn(
+      event: "too_many_requests",
+      user_id: current_user&.id,
+      controller: self.class.name,
+      action: action_name,
+      path: request.path,
+    )
+
+    render "errors/too_many_requests", status: :too_many_requests, formats: [:html]
+  end
+
 private
 
   # dfe and otp objects can both be instantiated as `.begin_session!` will always create

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
     Rails.logger.warn(
       event: "authorization_denied",
       user_id: current_user&.id,
-      controller: controller_name,
+      controller: self.class.name,
       action: action_name,
       path: request.path,
       policy: exception.policy.class.name,

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,14 +3,39 @@ class ErrorsController < ApplicationController
 
   def not_found
     check_user_is_authenticated
+
+    Rails.logger.warn(
+      event: "not_found",
+      user_id: current_user&.id,
+      controller: self.class.name,
+      action: action_name,
+      path: request.path,
+    )
+
     render "not_found", status: :not_found
   end
 
   def unprocessable_entity
+    Rails.logger.warn(
+      event: "unprocessable_entity",
+      user_id: current_user&.id,
+      controller: self.class.name,
+      action: action_name,
+      path: request.path,
+    )
+
     render "unprocessable_entity", status: :unprocessable_content
   end
 
   def internal_server_error
+    Rails.logger.warn(
+      event: "internal_server_error",
+      user_id: current_user&.id,
+      controller: self.class.name,
+      action: action_name,
+      path: request.path,
+    )
+
     render "internal_server_error", status: :internal_server_error
   end
 

--- a/app/controllers/users/deletes_controller.rb
+++ b/app/controllers/users/deletes_controller.rb
@@ -1,4 +1,6 @@
 class Users::DeletesController < CheckController
+  rate_limit to: 3, within: 3.minutes, only: :destroy, by: -> { current_user.id }
+
   def show
     @user = User.find(params[:user_id])
   end

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :page_title, "Sorry, there’s a problem completing this action" %>
+
+<h1 class="govuk-heading-l">Sorry, there’s a problem completing this action</h1>
+
+<p class="govuk-body">
+  You have tried this action too many times. Try again later.
+</p>
+
+<p class="govuk-body">
+  If you have any questions, email <%= support_email %>.
+</p>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Show full error reports.
   config.consider_all_requests_local = true
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable

--- a/spec/features/end_to_end/forbidden_access_spec.rb
+++ b/spec/features/end_to_end/forbidden_access_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Forbidden access" do
     expect(Rails.logger).to receive(:warn).with(
       event: "authorization_denied",
       user_id: current_api_user.id,
-      controller: "providers",
+      controller: "ProvidersController",
       action: "index",
       path: "/providers",
       policy: "ProviderPolicy",

--- a/spec/features/end_to_end/users/rate_limited_deleting_users_spec.rb
+++ b/spec/features/end_to_end/users/rate_limited_deleting_users_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.feature "User management" do
+  scenario "rate limited of a user deleting users" do
+    given_i_am_an_authenticated_user
+    and_i_have_users_to_delete
+    and_i_am_on_the_user_support_listing_page
+    and_i_can_see_the_page_title_users_with_the_count(count: 5)
+
+    Timecop.freeze(Time.zone.now) do
+      users_to_delete.each do |user_to_delete|
+        and_i_click_on(user_to_delete.name)
+        and_i_am_taken_to("/users/#{user_to_delete.id}")
+
+        and_i_click_on("Delete user2")
+        and_i_am_taken_to("/users/#{user_to_delete.id}/delete")
+
+        when_i_click_on("Delete user")
+        then_i_see_the_success_message
+        and_i_am_taken_to("/users")
+      end
+      and_i_can_see_the_page_title_users_with_the_count(count: 2)
+
+      and_i_click_on(user_fails_to_be_deleted.name)
+      and_i_am_taken_to("/users/#{user_fails_to_be_deleted.id}")
+
+      and_i_click_on("Delete user")
+      and_i_am_taken_to("/users/#{user_fails_to_be_deleted.id}/delete")
+
+      expect(Rails.logger).to receive(:warn).with(
+        event: "too_many_requests",
+        user_id: current_user.id,
+        controller: "Users::DeletesController",
+        action: "destroy",
+        path: "/users/#{user_fails_to_be_deleted.id}/delete",
+      )
+
+      when_i_click_on("Delete user")
+      and_i_can_see_the_page_title_for_not_able_to_complete_this_action
+      and_i_am_still_on("/users/#{user_fails_to_be_deleted.id}/delete")
+    end
+  end
+
+  def and_the_user_to_delete_is_deleted
+    expect(user_to_delete.reload).to be_discarded
+  end
+
+  def and_i_cannot_find(button_or_link)
+    expect(page).not_to have_button(button_or_link)
+    expect(page).not_to have_link(button_or_link)
+  end
+
+  def and_i_can_see_the_page_title_users_with_the_count(count: 1)
+    expect(page).to have_title("Users (#{count}) - Register of training providers - GOV.UK")
+  end
+
+  def and_i_am_on_the_user_support_listing_page
+    visit "/users"
+  end
+
+  def and_i_have_users_to_delete
+    users_to_delete
+    user_fails_to_be_deleted
+  end
+
+  def users_to_delete
+    @users_to_delete ||= create_list(:user, 3)
+  end
+
+  def user_fails_to_be_deleted
+    @user_fails_to_be_deleted ||= create(:user)
+  end
+
+  def and_i_can_see_the_warning_text
+    expect(page).to have_warning_text("Deleting a user is permanent – you cannot undo it.")
+  end
+
+  def then_i_see_the_success_message
+    expect(page).to have_notification_banner("Success", "User deleted")
+  end
+
+  def and_i_can_see_the_page_title_for_check_your_answers
+    expect(page).to have_title("Check your answers - Add user - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_confirm_you_want_to_delete_user
+    expect(page).to have_title("Confirm you want to delete user - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_view_user
+    expect(page).to have_title("View user - Register of training providers - GOV.UK")
+  end
+
+  def and_i_can_see_the_page_title_for_not_able_to_complete_this_action
+    expect(page).to have_title("Sorry, there’s a problem completing this action - Register of training providers - GOV.UK")
+  end
+end

--- a/spec/features/end_to_end/users/rate_limited_deleting_users_spec.rb
+++ b/spec/features/end_to_end/users/rate_limited_deleting_users_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "User management" do
         and_i_click_on(user_to_delete.name)
         and_i_am_taken_to("/users/#{user_to_delete.id}")
 
-        and_i_click_on("Delete user2")
+        and_i_click_on("Delete")
         and_i_am_taken_to("/users/#{user_to_delete.id}/delete")
 
         when_i_click_on("Delete user")

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -3,6 +3,14 @@ require "rails_helper"
 RSpec.describe "Error Pages", type: :request do
   describe "GET /404" do
     it "renders the 404 error page" do
+      expect(Rails.logger).to receive(:warn).with(
+        event: "not_found",
+        user_id: nil,
+        controller: "ErrorsController",
+        action: "not_found",
+        path: "/404",
+      )
+
       get "/404"
       expect(response).to have_http_status(:not_found)
       expect(response.body).to include("Page not found")
@@ -11,6 +19,13 @@ RSpec.describe "Error Pages", type: :request do
 
   describe "GET /422" do
     it "renders the 422 error page" do
+      expect(Rails.logger).to receive(:warn).with(
+        event: "unprocessable_entity",
+        user_id: nil,
+        controller: "ErrorsController",
+        action: "unprocessable_entity",
+        path: "/422",
+      )
       get "/422"
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("Sorry, there’s a problem with the service")
@@ -19,6 +34,13 @@ RSpec.describe "Error Pages", type: :request do
 
   describe "GET /500" do
     it "renders the 500 error page" do
+      expect(Rails.logger).to receive(:warn).with(
+        event: "internal_server_error",
+        user_id: nil,
+        controller: "ErrorsController",
+        action: "internal_server_error",
+        path: "/500",
+      )
       get "/500"
       expect(response).to have_http_status(:internal_server_error)
       expect(response.body).to include("Sorry, there’s a problem with the service")

--- a/spec/requests/users/deletes_controller_spec.rb
+++ b/spec/requests/users/deletes_controller_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "User deletion rate limit", type: :request do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user) }
+  let(:users_to_delete) { create_list :user, 3 }
+  let(:user_fails_to_be_deleted) { create(:user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user:)
+    get "/auth/dfe/callback"
+  end
+
+  after do
+    OmniAuth.config.mock_auth.clear
+  end
+
+  it "allows 3 deletes within 3 minutes but blocks the 4th" do
+    Timecop.freeze(Time.zone.now) do
+      users_to_delete.each do |user_to_delete|
+        delete user_delete_path(user_to_delete)
+        expect(response).to have_http_status(:redirect)
+      end
+
+      expect(Rails.logger).to receive(:warn).with(
+        event: "too_many_requests",
+        user_id: user.id,
+        controller: "Users::DeletesController",
+        action: "destroy",
+        path: "/users/#{user_fails_to_be_deleted.id}/delete",
+      )
+
+      delete user_delete_path(user_fails_to_be_deleted)
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+end

--- a/spec/support/capybara_screenshot_silencer.rb
+++ b/spec/support/capybara_screenshot_silencer.rb
@@ -1,0 +1,7 @@
+module SilentScreenshotReporter
+end
+
+if defined?(Capybara::Screenshot::RSpec::REPORTERS)
+  Capybara::Screenshot::RSpec::REPORTERS["RSpec::Core::Formatters::ProgressFormatter"] = SilentScreenshotReporter
+  Capybara::Screenshot::RSpec::REPORTERS["RSpec::Core::Formatters::DocumentationFormatter"] = SilentScreenshotReporter
+end

--- a/spec/support/failure_artifacts.rb
+++ b/spec/support/failure_artifacts.rb
@@ -1,0 +1,53 @@
+require "json"
+require "fileutils"
+
+module FailureArtifacts
+module_function
+
+  def capture(example)
+    FileUtils.mkdir_p("tmp/db_dumps")
+
+    timestamp = Time.zone.now.strftime("%Y-%m-%d-%H-%M-%S")
+
+    description = example.full_description
+                         .downcase
+                         .gsub(/\s+/, "-")
+                         .gsub(/["<>|:*?\\\/\r\n]/, "")
+                         .gsub(/[^a-z0-9\-_]/, "")
+
+    path = Rails.root.join(
+      "tmp/db_dumps",
+      "#{description}_#{timestamp}.json"
+    )
+
+    dump = {
+      "_metadata" => {
+        "example" => example.full_description,
+        "location" => example.location,
+        "exception" => example.exception.class.name,
+        "message" => example.exception.message,
+        "time" => Time.current.iso8601
+      }
+    }
+
+    ApplicationRecord.descendants
+                     .reject(&:abstract_class?)
+                     .select(&:table_exists?)
+                     .sort_by(&:name)
+                     .each do |model|
+      dump[model.name] = model.order(model.primary_key).map(&:attributes)
+    rescue StandardError => e
+      dump[model.name] = {
+        error: e.class.name,
+        message: e.message
+      }
+    end
+
+    File.write(
+      path,
+      JSON.pretty_generate(dump)
+    )
+
+    path.to_s
+  end
+end

--- a/spec/support/failure_capture.rb
+++ b/spec/support/failure_capture.rb
@@ -1,0 +1,19 @@
+# spec/support/failure_capture.rb
+require_relative "failure_artifacts"
+require_relative "capybara_screenshot_silencer"
+require_relative "failure_notification"
+
+RSpec.configure do |config|
+  config.before(:each) do |example|
+    example.metadata[:test_started_at] = Time.current
+  end
+
+  # Capture the exact time the test finishes and trigger dumps on failure
+  config.after(:each) do |example|
+    example.metadata[:test_finished_at] = Time.current
+
+    next unless example.exception
+
+    example.metadata[:db_dump_path] = FailureArtifacts.capture(example)
+  end
+end

--- a/spec/support/failure_notification.rb
+++ b/spec/support/failure_notification.rb
@@ -1,0 +1,66 @@
+require "rspec/core/notifications"
+
+module FailureNotification
+  def fully_formatted(failure_number, colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+    result = super
+
+    result += format_timing(example, colorizer)
+    result += format_db_dump(example, colorizer)
+    result += format_screenshots(example, colorizer)
+
+    result
+  end
+
+private
+
+  def base_dir
+    @base_dir ||= "#{Dir.pwd}/"
+  end
+
+  def format_timing(example, colorizer)
+    started_at = example.metadata[:test_started_at]
+    finished_at = example.metadata[:test_finished_at]
+
+    return "" unless started_at && finished_at
+
+    duration = (finished_at - started_at).round(3)
+    start_str = started_at.strftime("%H:%M:%S.%L")
+    end_str = finished_at.strftime("%H:%M:%S.%L")
+
+    colorizer.wrap("     Timing:\n", :red) +
+      colorizer.wrap("     # Started: #{start_str} | Finished: #{end_str} | Duration: #{duration}s\n", :yellow)
+  end
+
+  def format_db_dump(example, colorizer)
+    db_path = example.metadata[:db_dump_path]
+    return "" unless db_path
+
+    relative_path = db_path.to_s.sub(base_dir, "")
+
+    colorizer.wrap("     DB Dump:\n", :red) +
+      colorizer.wrap("     # ./#{relative_path}\n", :yellow)
+  end
+
+  def format_screenshots(example, colorizer)
+    screenshot = example.metadata[:screenshot]
+    return "" unless screenshot.is_a?(Hash)
+
+    output = ""
+
+    if (html_path = screenshot[:html])
+      relative_path = html_path.to_s.sub(base_dir, "")
+      output += colorizer.wrap("     HTML Screenshot:\n", :red)
+      output += colorizer.wrap("     # ./#{relative_path}\n", :yellow)
+    end
+
+    if (image_path = screenshot[:image])
+      relative_path = image_path.to_s.sub(base_dir, "")
+      output += colorizer.wrap("     Image Screenshot:\n", :red)
+      output += colorizer.wrap("     # ./#{relative_path}\n", :yellow)
+    end
+
+    output
+  end
+end
+
+RSpec::Core::Notifications::FailedExampleNotification.prepend(FailureNotification)

--- a/spec/support/features/navigation_helper.rb
+++ b/spec/support/features/navigation_helper.rb
@@ -9,4 +9,5 @@ module NavigationHelper
 
   alias_method :and_i_click_on, :when_i_click_on
   alias_method :and_i_am_taken_to, :then_i_am_taken_to
+  alias_method :and_i_am_still_on, :then_i_am_taken_to
 end


### PR DESCRIPTION
### Context
Users can be deleted in quick succession

### Changes proposed in this pull request
Throttle deleting of users
Log if a user ends up on the errors pages

### Guidance to review
Fixed a number of annoy minor issues

Try deleting more then 3 users  within 3 minutes

<img width="996" height="765" alt="image" src="https://github.com/user-attachments/assets/6a017387-429d-4367-b89c-698af0470d26" />
