### PR TITLE
2829 - Upgrade Postgres to v17 for production

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -15,5 +15,6 @@
   "external_url": "https://register-of-training-providers.education.gov.uk/healthcheck",
   "apex_url": "https://register-of-training-providers.education.gov.uk",
   "statuscake_contact_groups": [309326, 282453],
-  "enable_dfe_analytics_federated_auth": true
+  "enable_dfe_analytics_federated_auth": true,
+  "postgres_version": 17
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -130,7 +130,7 @@ variable "job_name" {
   default     = "migrations"
 }
 
-variable "postgres_version" { default = 16 }
+variable "postgres_version" { default = 17 }
 
 variable "enable_dfe_analytics_federated_auth" {
   description = "Create the resources in Google cloud for federated authentication and enable in application"


### PR DESCRIPTION
### Context

We need to upgrade Postgres DB to version 17.
https://trello.com/c/m6tlxrdZ/2829-upgrade-rotp-postgres-version

### Changes proposed in this pull request

postgres_version = 17 added to production and default  changed to 17

### Guidance to review

Run command `make production terraform-plan CONFIRM_PRODUCTION=yes`
This should show the change in Postgres version from 16 to 17 in production only.

Only merge after the upgrade has been completed manually  through the portal.