### PR TITLE
[0550] Ensure at least x users cannot be soft deleted and or deactivated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,20 @@ class ApplicationController < ActionController::Base
     render "errors/too_many_requests", status: :too_many_requests, formats: [:html]
   end
 
+  rescue_from MinimumActiveUsersError do
+    Rails.logger.warn(
+      event: "minimum_active_users_violation",
+      user_id: current_user&.id,
+      remaining_active_users: User.kept.where(active: true).count,
+      total_users: User.count,
+      controller: controller_name,
+      action: action_name,
+      path: request.path
+    )
+
+    render "errors/conflict", status: :conflict, formats: [:html]
+  end
+
 private
 
   # dfe and otp objects can both be instantiated as `.begin_session!` will always create

--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -22,8 +22,12 @@ private
   def post_save
   end
 
+  def pre_save
+  end
+
   def save
     authorize model
+    pre_save
     if model.save
       post_save
       redirect_to success_path, flash: flash_message

--- a/app/controllers/users/check_controller.rb
+++ b/app/controllers/users/check_controller.rb
@@ -8,4 +8,12 @@ class Users::CheckController < CheckController
       )
     end
   end
+
+  def pre_save
+    if model.changes["active"] == [true, false]
+
+      User.ensure_minimum_active_users!(users_id_to_exclude: model.id)
+
+    end
+  end
 end

--- a/app/controllers/users/deletes_controller.rb
+++ b/app/controllers/users/deletes_controller.rb
@@ -7,6 +7,9 @@ class Users::DeletesController < CheckController
 
   def destroy
     @user = User.find(params[:user_id])
+
+    User.ensure_minimum_active_users!(users_id_to_exclude: @user.id)
+
     @user.discard!
     redirect_to(users_path, flash: { success: "User deleted" })
   end

--- a/app/errors/minimum_active_users_error.rb
+++ b/app/errors/minimum_active_users_error.rb
@@ -1,0 +1,2 @@
+class MinimumActiveUsersError < StandardError
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,10 @@ class User < ApplicationRecord
 
   after_save :revoke_all_active_tokens_for_api_clients!, unless: :active?
 
+  def self.ensure_minimum_active_users!(users_id_to_exclude:)
+    raise MinimumActiveUsersError if User.kept.where(active: true).where.not(id: users_id_to_exclude).count < 4
+  end
+
   def name
     first_name_to_use = first_name_was || first_name
     last_name_to_use = last_name_was || last_name

--- a/app/views/errors/conflict.html.erb
+++ b/app/views/errors/conflict.html.erb
@@ -1,0 +1,15 @@
+<%= content_for :page_title, "Sorry, you cannot complete this action" %>
+
+<h1 class="govuk-heading-l">Sorry, you cannot complete this action</h1>
+
+<p class="govuk-body">
+  We cannot complete this action at the moment.
+</p>
+
+<p class="govuk-body">
+  Try again later.
+</p>
+
+<p class="govuk-body">
+  If you continue to have problems, email <%= support_email %>.
+</p>

--- a/spec/features/end_to_end/users/deleting_user_spec.rb
+++ b/spec/features/end_to_end/users/deleting_user_spec.rb
@@ -1,32 +1,74 @@
 require "rails_helper"
 
 RSpec.feature "User management" do
-  scenario "deleting users" do
-    given_i_am_an_authenticated_user
-    and_i_have_a_user_to_delete
-    and_i_am_on_the_user_support_listing_page
-    and_i_can_see_the_page_title_users_with_the_count(count: 2)
+  context "when deleting a user leaves the minimum required number of users" do
+    scenario "allows deletion" do
+      given_i_am_an_authenticated_user
+      and_i_have_additional_users(number_of_users: 3)
+      and_i_have_a_user_to_delete
+      and_i_am_on_the_user_support_listing_page
+      and_i_can_see_the_page_title_users_with_the_count(count: 5)
 
-    and_i_click_on(current_user.name)
-    and_i_cannot_find("Delete user")
+      and_i_click_on(current_user.name)
+      and_i_cannot_find("Delete user")
 
-    and_i_click_on("Back")
-    and_i_click_on(user_to_delete.name)
-    and_i_am_taken_to("/users/#{user_to_delete.id}")
+      and_i_click_on("Back")
+      and_i_click_on(user_to_delete.name)
+      and_i_am_taken_to("/users/#{user_to_delete.id}")
 
-    and_i_can_see_the_page_title_for_view_user
-    and_i_click_on("Delete user")
-    and_i_am_taken_to("/users/#{user_to_delete.id}/delete")
+      and_i_can_see_the_page_title_for_view_user
+      and_i_click_on("Delete user")
+      and_i_am_taken_to("/users/#{user_to_delete.id}/delete")
 
-    and_i_can_see_the_page_title_for_confirm_you_want_to_delete_user
-    and_i_can_see_the_warning_text
-    when_i_click_on("Delete user")
-    then_i_see_the_success_message
-    and_i_am_taken_to("/users")
+      and_i_can_see_the_page_title_for_confirm_you_want_to_delete_user
+      and_i_can_see_the_warning_text
+      when_i_click_on("Delete user")
+      then_i_see_the_success_message
+      and_i_am_taken_to("/users")
 
-    and_i_can_see_the_page_title_users_with_the_count(count: 1)
-    and_i_cannot_find(user_to_delete.name)
-    and_the_user_to_delete_is_deleted
+      and_i_can_see_the_page_title_users_with_the_count(count: 4)
+      and_i_cannot_find(user_to_delete.name)
+      and_the_user_to_delete_is_deleted
+    end
+  end
+
+  context "when deleting a user would go below the minimum required number of users" do
+    scenario "prevents deletion" do
+      given_i_am_an_authenticated_user
+      and_i_have_additional_users(number_of_users: 2)
+      and_i_have_a_user_to_delete
+      and_i_am_on_the_user_support_listing_page
+      and_i_can_see_the_page_title_users_with_the_count(count: 4)
+
+      and_i_click_on(user_to_delete.name)
+      and_i_am_taken_to("/users/#{user_to_delete.id}")
+
+      and_i_can_see_the_page_title_for_view_user
+      and_i_click_on("Delete user")
+      and_i_am_taken_to("/users/#{user_to_delete.id}/delete")
+
+      and_i_can_see_the_page_title_for_confirm_you_want_to_delete_user
+      and_i_can_see_the_warning_text
+
+      expect(Rails.logger).to receive(:warn).with(
+        event: "minimum_active_users_violation",
+        user_id: current_user.id,
+        remaining_active_users: 4,
+        total_users: 4,
+        action: "destroy",
+        controller: "deletes",
+        path: "/users/#{user_to_delete.id}/delete",
+      )
+
+      when_i_click_on("Delete user")
+
+      and_i_can_see_the_page_title_for_you_cannot_complete_this_action
+      and_i_am_still_on("/users/#{user_to_delete.id}/delete")
+    end
+  end
+
+  def and_i_can_see_the_page_title_for_you_cannot_complete_this_action
+    expect(page).to have_title("Sorry, you cannot complete this action - Register of training providers - GOV.UK")
   end
 
   def and_the_user_to_delete_is_deleted
@@ -48,6 +90,10 @@ RSpec.feature "User management" do
 
   def user_to_delete
     @user_to_delete ||= create(:user)
+  end
+
+  def and_i_have_additional_users(number_of_users:)
+    create_list(:user, number_of_users)
   end
 
   def and_i_can_see_the_warning_text

--- a/spec/features/end_to_end/users/rate_limited_deleting_users_spec.rb
+++ b/spec/features/end_to_end/users/rate_limited_deleting_users_spec.rb
@@ -4,8 +4,10 @@ RSpec.feature "User management" do
   scenario "rate limited of a user deleting users" do
     given_i_am_an_authenticated_user
     and_i_have_users_to_delete
+    and_i_have_additional_users(number_of_users: 3)
+
     and_i_am_on_the_user_support_listing_page
-    and_i_can_see_the_page_title_users_with_the_count(count: 5)
+    and_i_can_see_the_page_title_users_with_the_count(count: 8)
 
     Timecop.freeze(Time.zone.now) do
       users_to_delete.each do |user_to_delete|
@@ -19,7 +21,7 @@ RSpec.feature "User management" do
         then_i_see_the_success_message
         and_i_am_taken_to("/users")
       end
-      and_i_can_see_the_page_title_users_with_the_count(count: 2)
+      and_i_can_see_the_page_title_users_with_the_count(count: 5)
 
       and_i_click_on(user_fails_to_be_deleted.name)
       and_i_am_taken_to("/users/#{user_fails_to_be_deleted.id}")
@@ -39,6 +41,10 @@ RSpec.feature "User management" do
       and_i_can_see_the_page_title_for_not_able_to_complete_this_action
       and_i_am_still_on("/users/#{user_fails_to_be_deleted.id}/delete")
     end
+  end
+
+  def and_i_have_additional_users(number_of_users:)
+    create_list(:user, number_of_users)
   end
 
   def and_the_user_to_delete_is_deleted

--- a/spec/features/end_to_end/users/setting_user_to_inactive_spec.rb
+++ b/spec/features/end_to_end/users/setting_user_to_inactive_spec.rb
@@ -1,56 +1,98 @@
 require "rails_helper"
 
 RSpec.feature "User management" do
-  scenario "editing users" do
-    given_i_am_an_authenticated_user
-    and_i_have_a_user_to_set_to_inactive
-    and_i_am_on_the_user_support_listing_page
-    and_i_can_see_the_page_title_users_with_the_count(count: 2)
+  context "when updating user as inactive leaves the minimum required number of users" do
+    scenario "prevent setting user as inactive" do
+      given_i_am_an_authenticated_user
+      and_i_have_additional_users(number_of_users: 3)
 
-    and_i_click_on(user_to_deactivate.name)
-    and_i_can_see_the_page_title_for_view_user
-    and_i_click_on("Change is the account active?")
-    and_i_am_taken_to("/users/#{user_to_deactivate.id}/edit")
+      and_i_have_a_user_to_set_to_inactive
+      and_i_am_on_the_user_support_listing_page
+      and_i_can_see_the_page_title_users_with_the_count(count: 5)
 
-    and_i_can_see_the_page_title_for_personal_details
-    and_i_do_not_see_error_summary
+      and_i_click_on(user_to_deactivate.name)
+      and_i_can_see_the_page_title_for_view_user
+      and_i_click_on("Change is the account active?")
+      and_i_am_taken_to("/users/#{user_to_deactivate.id}/edit")
 
-    and_i_set_the_user_to_inactive
+      and_i_can_see_the_page_title_for_personal_details
+      and_i_do_not_see_error_summary
 
-    and_i_click_on("Continue")
+      and_i_set_the_user_to_inactive
 
-    and_i_am_taken_to("/users/#{user_to_deactivate.id}/check")
+      and_i_click_on("Continue")
 
-    and_i_can_see_the_page_title_for_check_your_answers
+      and_i_am_taken_to("/users/#{user_to_deactivate.id}/check")
 
-    expect(Rails.logger).to receive(:warn).with(
-      event: "user_deactivated",
-      user_id: current_user.id,
-      deactivate_user_id: user_to_deactivate.id,
-    )
+      and_i_can_see_the_page_title_for_check_your_answers
 
-    when_i_click_on("Save user")
+      expect(Rails.logger).to receive(:warn).with(
+        event: "user_deactivated",
+        user_id: current_user.id,
+        deactivate_user_id: user_to_deactivate.id,
+      )
 
-    then_i_see_the_success_message
-    and_i_am_taken_to("/users")
+      when_i_click_on("Save user")
 
-    and_i_can_see_the_page_title_users_with_the_count(count: 2)
+      then_i_see_the_success_message
+      and_i_am_taken_to("/users")
+
+      and_i_can_see_the_page_title_users_with_the_count(count: 5)
+    end
+  end
+
+  context "when updating user as inactive would go below the minimum required number of users" do
+    scenario "prevent setting user as inactive" do
+      given_i_am_an_authenticated_user
+      and_i_have_additional_users(number_of_users: 2)
+
+      and_i_have_a_user_to_set_to_inactive
+      and_i_am_on_the_user_support_listing_page
+      and_i_can_see_the_page_title_users_with_the_count(count: 4)
+
+      and_i_click_on(user_to_deactivate.name)
+      and_i_can_see_the_page_title_for_view_user
+      and_i_click_on("Change is the account active?")
+      and_i_am_taken_to("/users/#{user_to_deactivate.id}/edit")
+
+      and_i_can_see_the_page_title_for_personal_details
+      and_i_do_not_see_error_summary
+
+      and_i_set_the_user_to_inactive
+
+      and_i_click_on("Continue")
+
+      and_i_am_taken_to("/users/#{user_to_deactivate.id}/check")
+
+      and_i_can_see_the_page_title_for_check_your_answers
+
+      expect(Rails.logger).to receive(:warn).with(
+        event: "minimum_active_users_violation",
+        user_id: current_user.id,
+        remaining_active_users: 4,
+        total_users: 4,
+        action: "update",
+        controller: "check",
+        path: "/users/#{user_to_deactivate.id}/check",
+      )
+
+      when_i_click_on("Save user")
+
+      and_i_can_see_the_page_title_for_you_cannot_complete_this_action
+      and_i_am_still_on("/users/#{user_to_deactivate.id}/check")
+    end
+  end
+
+  def and_i_can_see_the_page_title_for_you_cannot_complete_this_action
+    expect(page).to have_title("Sorry, you cannot complete this action - Register of training providers - GOV.UK")
+  end
+
+  def and_i_have_additional_users(number_of_users:)
+    create_list(:user, number_of_users)
   end
 
   def and_i_set_the_user_to_inactive
     page.choose("No", name: "user[active]")
-  end
-
-  def and_the_user_to_deactivate_is_edited
-    expect(user_to_deactivate.reload.first_name).to eq(new_first_name)
-  end
-
-  def new_first_name
-    "Nouveau"
-  end
-
-  def old_first_name
-    "Vieux"
   end
 
   def and_i_see_my_changes(link)
@@ -71,7 +113,7 @@ RSpec.feature "User management" do
   end
 
   def user_to_deactivate
-    @user_to_deactivate ||= create(:user, first_name: old_first_name)
+    @user_to_deactivate ||= create(:user)
   end
 
   def old_user_to_deactivate_name

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -243,6 +243,58 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe ".ensure_minimum_active_users!" do
+    context "when excluding the user would leave at least 4 kept active users" do
+      let!(:users) { create_list(:user, 5, active: true) }
+
+      it "does not raise an error" do
+        expect {
+          described_class.ensure_minimum_active_users!(
+            users_id_to_exclude: users.first.id
+          )
+        }.not_to raise_error
+      end
+    end
+
+    context "when excluding the user would leave fewer than 4 kept active users" do
+      let!(:users) { create_list(:user, 4, active: true) }
+
+      it "raises MinimumActiveUsersError" do
+        expect {
+          described_class.ensure_minimum_active_users!(
+            users_id_to_exclude: users.first.id
+          )
+        }.to raise_error(MinimumActiveUsersError)
+      end
+    end
+
+    context "when there are inactive users" do
+      let!(:active_users) { create_list(:user, 4, active: true) }
+      let!(:inactive_user) { create(:user, active: false) }
+
+      it "does not count inactive users" do
+        expect {
+          described_class.ensure_minimum_active_users!(
+            users_id_to_exclude: active_users.first.id
+          )
+        }.to raise_error(MinimumActiveUsersError)
+      end
+    end
+
+    context "when there are discarded active users" do
+      let!(:active_users) { create_list(:user, 4, active: true) }
+      let!(:discarded_user) { create(:user, active: true, discarded_at: Time.current) }
+
+      it "does not count discarded users" do
+        expect {
+          described_class.ensure_minimum_active_users!(
+            users_id_to_exclude: active_users.first.id
+          )
+        }.to raise_error(MinimumActiveUsersError)
+      end
+    end
+  end
+
   describe "#active?" do
     it "is true by default" do
       expect(user.active?).to be true

--- a/spec/requests/users/deletes_controller_spec.rb
+++ b/spec/requests/users/deletes_controller_spec.rb
@@ -2,10 +2,13 @@ RSpec.describe "User deletion rate limit", type: :request do
   include DfESignInUserHelper
 
   let(:user) { create(:user) }
+  let(:additional_users) { create_list :user, 3 }
   let(:users_to_delete) { create_list :user, 3 }
   let(:user_fails_to_be_deleted) { create(:user) }
 
   before do
+    additional_users
+
     user_exists_in_dfe_sign_in(user:)
     get "/auth/dfe/callback"
   end


### PR DESCRIPTION
### Context

x users cannot be soft deleted and or deactivated

### Changes proposed in this pull request
Ensure at least x users cannot be soft deleted and or deactivated

### Guidance to review
When a user tries to deactivate or soft delete a user then a check is done to ensure it does not fall below 4 active users

<img width="960" height="727" alt="image" src="https://github.com/user-attachments/assets/b10811e2-727c-4db5-a27d-0babc7197e56" />
