### PR TITLE
[0502] Make `RoTP Id` immutable

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -86,6 +86,8 @@ class Provider < ApplicationRecord
   end
 
   validates :rotp_id, uniqueness: true, presence: true, unless: :without_rotp_id?
+  validate :rotp_id_immutable, on: :update
+
   validates :provider_type, presence: true, provider_type: true
 
   include AccreditationStatusValidator
@@ -240,5 +242,11 @@ private
 
   def without_rotp_id?
     validation_context == :without_rotp_id
+  end
+
+  def rotp_id_immutable
+    return unless rotp_id_changed? && rotp_id_was.present?
+
+    errors.add(:rotp_id, "cannot be changed")
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -459,5 +459,16 @@ RSpec.describe Provider, type: :model do
 
       expect(provider.valid?(:without_rotp_id)).to be(true)
     end
+
+    it "does not allow an existing RoTP Id to be changed" do
+      provider = create(:provider, rotp_id: "CANNOT CHANGE")
+
+      expect {
+        provider.update!(rotp_id: "LET'S TRY TO CHANGE IT")
+      }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Rotp cannot be changed")
+
+      expect(provider.errors[:rotp_id]).to eq(["cannot be changed"])
+      expect(provider.reload.rotp_id).to eq("CANNOT CHANGE")
+    end
   end
 end


### PR DESCRIPTION
### Context
`RoTP Id` immutable

### Changes proposed in this pull request
Added `RoTP Id` validation for changing exist `RoTP Id`

### Guidance to review
This is to  ensure we do not accidentally change it without knowing